### PR TITLE
Parsing the most basic screwdriver.yaml parsing (supports just steps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@
 npm install screwdriver-config-parser
 ```
 
+Parse in Node.js
+
+```javascript
+const parser = require('screwdriver-config-parser');
+
+parser({
+    // Configuration (in YAML form)
+    yaml: fs.readFileSync('sample.yaml', 'utf-8'),
+    // Name of current job
+    jobName: 'main'
+}, (err, data) => {
+    // data.execute contains the commands to execute
+    fs.writeFileSync('execute.json', JSON.stringify(data.execute));
+});
+```
+
+Or via the command line
+
+```bash
+config-parse path/to/screwdriver.yaml job-name path-to-artifacts-dir
+```
+
 ## Testing
 
 ```bash

--- a/bin/config-parse.js
+++ b/bin/config-parse.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+'use strict';
+
+const winston = require('winston');
+const parser = require('../');
+const fs = require('fs');
+const path = require('path');
+
+const yaml = fs.readFileSync(process.argv[2], 'utf-8');
+const jobName = process.argv[3];
+const destination = process.argv[4];
+
+winston.remove(winston.transports.Console);
+winston.add(winston.transports.Console, {
+    showLevel: false
+});
+
+parser({ yaml, jobName }, (err, data) => {
+    if (err) {
+        winston.error(err);
+        process.exit(err.code || 127);
+    }
+
+    // Commands to execute
+    fs.writeFileSync(path.join(destination, 'execute.json'), JSON.stringify(data.execute));
+});

--- a/index.js
+++ b/index.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const Yaml = require('js-yaml');
+const Joi = require('joi');
+const Hoek = require('hoek');
+const Async = require('async');
+
+const REGEX_STEP_NAME = /^[\w-]+$/;
+const REGEX_JOB_NAME = /^[\w-]+$/;
+const SCHEMA_STEPS = Joi.object()
+    // Steps can only be named with A-Z,a-z,0-9,-,_
+    // Steps only contain strings (the command to execute)
+    .pattern(REGEX_STEP_NAME, Joi.string())
+    // All others are marked as invalid
+    .unknown(false)
+    // At least one command is required
+    .min(1)
+    // Add documentation
+    .options({
+        language: {
+            object: {
+                min: 'requires at least one step',
+                allowUnknown: 'only supports the following characters A-Z,a-z,0-9,-,_'
+            }
+        }
+    });
+const SCHEMA_JOB = Joi.object({
+    steps: SCHEMA_STEPS
+});
+
+/**
+ * Generate a Joi configuration that requires the {jobName} job to exist
+ * @method makeConfigSchema
+ * @param  {String}   jobName Current Job (desired job)
+ * @return {Joi}              Joi Schema for the config file
+ */
+function makeConfigSchema(jobName) {
+    const requiredJobs = ['main', jobName];
+    const jobSchema = {};
+
+    requiredJobs.forEach((name) => {
+        jobSchema[name] = SCHEMA_JOB.required();
+    });
+
+    const jobs = Joi.object().keys(jobSchema)
+        // Jobs can only be named with A-Z,a-z,0-9,-,_
+        .pattern(REGEX_JOB_NAME, SCHEMA_JOB)
+        // All others are marked as invalid
+        .unknown(false)
+        .options({
+            language: {
+                object: {
+                    allowUnknown: 'only supports the following characters A-Z,a-z,0-9,-,_'
+                }
+            }
+        });
+
+    return Joi.object().keys({ jobs })
+        // Jobs is the only field in the screwdriver.yaml
+        .requiredKeys('jobs')
+        // No other fields are allowed
+        .unknown(false);
+}
+
+/**
+ * Parse the configuration from a screwdriver.yaml
+ * @method configParser
+ * @param  {Object}   config
+ * @param  {String}   config.yaml           Contents of screwdriver.yaml
+ * @param  {String}   [config.jobName=main] Job to parse for
+ * @param  {Function} callback              Function to call when done (error, { execute })
+ */
+module.exports = function configParser(config, callback) {
+    const paramSchema = Joi.object().keys({
+        yaml: Joi.string()
+            .required(),
+        jobName: Joi.string()
+            .regex(/^[\w-]+$/)
+            .optional()
+            .default('main')
+    });
+    const defaultOptions = {
+        abortEarly: false
+    };
+    let globalConfig = {};
+
+    Async.waterfall([
+        Async.apply(Joi.validate, config, paramSchema, defaultOptions),
+        (parsedConfig, next) => {
+            globalConfig = Object.assign({}, parsedConfig);
+
+            try {
+                globalConfig.yaml = Yaml.safeLoad(parsedConfig.yaml);
+            } catch (parseError) {
+                return next(parseError);
+            }
+
+            const configSchema = makeConfigSchema(parsedConfig.jobName);
+
+            return Joi.validate(globalConfig.yaml, configSchema, defaultOptions, next);
+        },
+        (parsedDoc, next) => {
+            const execute = Hoek.reach(parsedDoc, `jobs.${globalConfig.jobName}.steps`);
+
+            return next(null, {
+                execute
+            });
+        }
+    ], callback);
+};

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "screwdriver-config-parser",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Node module for parsing screwdriver.yaml configurations",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
     "test": "jenkins-mocha --recursive"
+  },
+  "bin": {
+    "config-parse": "./bin/config-parse.js"
   },
   "repository": {
     "type": "git",
@@ -37,5 +40,11 @@
     "eslint-plugin-react": "^5.1.1",
     "jenkins-mocha": "^2.6.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "async": "^2.0.0-rc.6",
+    "hoek": "^4.0.1",
+    "joi": "^8.4.2",
+    "js-yaml": "^3.6.1",
+    "winston": "^2.2.0"
+  }
 }

--- a/test/data/bad-step-name.yaml
+++ b/test/data/bad-step-name.yaml
@@ -1,0 +1,4 @@
+jobs:
+    main:
+        steps:
+            "foo bar": baz

--- a/test/data/basic-project.yaml
+++ b/test/data/basic-project.yaml
@@ -1,0 +1,10 @@
+jobs:
+    main:
+        steps:
+            install: npm install
+            test: npm test
+            publish: npm publish
+    foobar:
+        steps:
+            install: npm install
+            test: npm test

--- a/test/data/missing-main-job.yaml
+++ b/test/data/missing-main-job.yaml
@@ -1,0 +1,6 @@
+jobs:
+    foobar:
+        steps:
+            install: npm install
+            test: npm test
+            publish: npm publish

--- a/test/data/not-enough-commands.yaml
+++ b/test/data/not-enough-commands.yaml
@@ -1,0 +1,3 @@
+jobs:
+    main:
+        steps: {}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,128 @@
 'use strict';
 const assert = require('chai').assert;
+const parser = require('../');
+const fs = require('fs');
+const path = require('path');
 
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+/**
+ * Load sample data from disk
+ * @method loadData
+ * @param  {String} name Filename to read (inside data dir)
+ * @return {String}      Contents of file
+ */
+function loadData(name) {
+    return fs.readFileSync(path.join(__dirname, 'data', name), 'utf-8');
+}
+
+describe('config parser', () => {
+    describe('input validation', () => {
+        it('returns an error if unparsable yaml', (done) => {
+            parser({
+                yaml: 'foo: :',
+                jobName: 'main'
+            }, (err) => {
+                assert.isNotNull(err);
+                assert.match(err.toString(), /YAMLException:/);
+                done();
+            });
+        });
+
+        it('returns an error if missing fields', (done) => {
+            parser({}, (err) => {
+                assert.isNotNull(err);
+                assert.match(err.toString(), /ValidationError/);
+                done();
+            });
+        });
+    });
+
+    describe('config validation', () => {
+        describe('overall config', () => {
+            it('returns an error if missing jobs', (done) => {
+                parser({
+                    yaml: 'foo: bar'
+                }, (err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /"jobs" is required/);
+                    done();
+                });
+            });
+        });
+
+        describe('jobs', () => {
+            it('returns an error if missing main job', (done) => {
+                parser({
+                    yaml: loadData('missing-main-job.yaml')
+                }, (err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /"main" is required/);
+                    done();
+                });
+            });
+
+            it('returns an error if missing desired job', (done) => {
+                parser({
+                    yaml: loadData('basic-project.yaml'),
+                    jobName: 'barfoo'
+                }, (err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /"barfoo" is required/);
+                    done();
+                });
+            });
+        });
+
+        describe('steps', () => {
+            it('returns an error if not enough steps', (done) => {
+                parser({
+                    yaml: loadData('not-enough-commands.yaml')
+                }, (err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /"steps" requires at least one step/);
+                    done();
+                });
+            });
+
+            it('returns an error if not bad named steps', (done) => {
+                parser({
+                    yaml: loadData('bad-step-name.yaml')
+                }, (err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(),
+                        /"foo bar" only supports the following characters A-Z,a-z,0-9,-,_/);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('execute', () => {
+        it('returns execution plans for basic project', (done) => {
+            parser({
+                yaml: loadData('basic-project.yaml')
+            }, (err, data) => {
+                assert.isNull(err);
+                assert.deepEqual(data.execute, {
+                    install: 'npm install',
+                    test: 'npm test',
+                    publish: 'npm publish'
+                });
+                done();
+            });
+        });
+
+        it('returns execution plans for basic non-main job', (done) => {
+            parser({
+                yaml: loadData('basic-project.yaml'),
+                jobName: 'foobar'
+            }, (err, data) => {
+                assert.isNull(err);
+                assert.deepEqual(data.execute, {
+                    install: 'npm install',
+                    test: 'npm test'
+                });
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
This parses the most basic screwdriver.yaml:

``` yaml
jobs:
  main:
    steps:
      foo: bar
```

and produces data for the https://www.npmjs.com/package/screwdriver-launcher-execute
