### PR TITLE
Adding s3cr3t support to the screwdriver.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ jobs:
             - bump: npm run bump
             - publish: npm publish --tag $NODE_TAG
             - tag: git push origin --tags
+        secrets:
+            - NPM_TOKEN
+            - GIT_KEY
 ```
 
 ## Usage

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -18,6 +18,7 @@ function flattenSharedIntoJobs(shared, jobs) {
         const newJob = clone(shared);
         const oldJob = clone(jobs[jobName]);
 
+        // Replace
         ['image', 'matrix', 'steps'].forEach((key) => {
             if (oldJob[key]) {
                 newJob[key] = oldJob[key];
@@ -27,8 +28,13 @@ function flattenSharedIntoJobs(shared, jobs) {
         if (!newJob.environment) {
             newJob.environment = {};
         }
+        if (!newJob.secrets) {
+            newJob.secrets = [];
+        }
 
+        // Merge
         Object.assign(newJob.environment, oldJob.environment || {});
+        newJob.secrets = newJob.secrets.concat(oldJob.secrets || []);
 
         newJobs[jobName] = newJob;
     });

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -77,7 +77,7 @@ function validateJobSteps(job, prefix) {
     });
 
     steps.forEach((step) => {
-        if (step.name.indexOf('sd-') === 0) {
+        if (step.name.toLowerCase().indexOf('sd-') === 0) {
             errors.push(`${prefix}: Step "${step.name}": `
                 + 'cannot use a restricted prefix "sd-"');
         }
@@ -124,6 +124,11 @@ function validateJobSchema(doc) {
             Joi.attempt(doc.jobs[jobName], SCHEMA_JOB, prefix);
         } catch (err) {
             errors.push(err.message);
+        }
+
+        // Check special prefixes
+        if (jobName.toLowerCase().indexOf('pr-') === 0) {
+            errors.push(`${prefix}: cannot use a restricted prefix "pr-"`);
         }
 
         errors = errors.concat(validateJobMatrix(doc.jobs[jobName], prefix));

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -20,6 +20,7 @@ module.exports = (validatedDoc, callback) => {
         const job = {
             image: Hoek.reach(doc, `jobs.${jobName}.image`),
             commands: Hoek.reach(doc, `jobs.${jobName}.commands`),
+            secrets: Hoek.reach(doc, `jobs.${jobName}.secrets`),
             environment: Hoek.reach(doc, `jobs.${jobName}.environment`, {
                 default: {}
             })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-config-parser",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Node module for parsing screwdriver.yaml configurations",
   "main": "index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "joi": "^9.0.1",
     "js-yaml": "^3.6.1",
     "keymbinatorial": "^1.0.0",
-    "screwdriver-data-schema": "^9.0.0",
+    "screwdriver-data-schema": "^10.3.0",
     "tinytim": "^0.1.1"
   }
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,14 +1,15 @@
+workflow:
+    - publish
+
+shared:
+    image: node:6
+
 jobs:
     main:
-        image: node:{{NODE_VERSION}}
-        matrix:
-            NODE_VERSION: [4,5,6]
         steps:
-            - npm install
+            - install: npm install
             - test: npm test
-            - build: npm run build
 
     publish:
-        image: node:4
         steps:
             - install: npm publish

--- a/test/data/basic-shared-project.json
+++ b/test/data/basic-shared-project.json
@@ -21,7 +21,10 @@
                     "FOO": "bar",
                     "BAR": "foo",
                     "DIRECTORY": "c"
-                }
+                },
+                "secrets": [
+                    "GIT_KEY"
+                ]
             },
             {
                 "image": "node:4",
@@ -43,7 +46,10 @@
                     "FOO": "bar",
                     "BAR": "foo",
                     "DIRECTORY": "d"
-                }
+                },
+                "secrets": [
+                    "GIT_KEY"
+                ]
             }
         ],
         "foobar": [
@@ -60,7 +66,11 @@
                     "BAZ": "foo",
                     "VERSION": "1",
                     "DIRECTORY": "a"
-                }
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ]
             },
             {
                 "image": "node:4",
@@ -75,7 +85,11 @@
                     "BAZ": "foo",
                     "VERSION": "1",
                     "DIRECTORY": "b"
-                }
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ]
             },
             {
                 "image": "node:4",
@@ -90,7 +104,11 @@
                     "BAZ": "foo",
                     "VERSION": "2",
                     "DIRECTORY": "a"
-                }
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ]
             },
             {
                 "image": "node:4",
@@ -105,7 +123,11 @@
                     "BAZ": "foo",
                     "VERSION": "2",
                     "DIRECTORY": "b"
-                }
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ]
             }
         ]
     },

--- a/test/data/basic-shared-project.yaml
+++ b/test/data/basic-shared-project.yaml
@@ -7,6 +7,8 @@ shared:
     matrix:
         VERSION: [1,2]
         DIRECTORY: [a,b]
+    secrets:
+        - GIT_KEY
 
 jobs:
     main:
@@ -24,3 +26,5 @@ jobs:
         environment:
             BAZ: foo
             FOO: ban
+        secrets:
+            - NPM_TOKEN

--- a/test/data/complex-environment.json
+++ b/test/data/complex-environment.json
@@ -16,7 +16,8 @@
                     "NUMBER": "3",
                     "DECIMAL": "3.1415927",
                     "STRING": "test"
-                }
+                },
+                "secrets": []
             }
         ]
     },

--- a/test/data/node-module.json
+++ b/test/data/node-module.json
@@ -16,7 +16,8 @@
                 "environment": {
                     "NODE_ENV": "test",
                     "NODE_VERSION": "4"
-                }
+                },
+                "secrets": []
             },
             {
                 "image": "node:5",
@@ -33,7 +34,8 @@
                 "environment": {
                     "NODE_ENV": "test",
                     "NODE_VERSION": "5"
-                }
+                },
+                "secrets": []
             },
             {
                 "image": "node:6",
@@ -50,7 +52,8 @@
                 "environment": {
                     "NODE_ENV": "test",
                     "NODE_VERSION": "6"
-                }
+                },
+                "secrets": []
             }
         ],
         "publish": [
@@ -73,7 +76,10 @@
                 "environment": {
                     "NODE_ENV": "test",
                     "NODE_TAG": "latest"
-                }
+                },
+                "secrets": [
+                    "NPM_TOKEN"
+                ]
             }
         ]
     },

--- a/test/data/node-module.yaml
+++ b/test/data/node-module.yaml
@@ -22,3 +22,5 @@ jobs:
             - bump: npm run bump
             - publish: npm publish --tag $NODE_TAG
             - tag: git push origin --tags
+        secrets:
+            - NPM_TOKEN

--- a/test/data/restricted-job-name.yaml
+++ b/test/data/restricted-job-name.yaml
@@ -1,0 +1,9 @@
+jobs:
+    main:
+        image: node:4
+        steps:
+            - setup: woot
+    pr-15:
+        image: node:4
+        steps:
+            - setup: woot

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -153,6 +153,15 @@ describe('config parser', () => {
                 done();
             });
         });
+
+        it('returns an error if using restricted job names', (done) => {
+            parser(loadData('restricted-job-name.yaml'), (err) => {
+                assert.isNotNull(err);
+                assert.match(err.toString(),
+                    /Job "pr-15": cannot use a restricted prefix "pr-"/);
+                done();
+            });
+        });
     });
 
     describe('permutation', () => {


### PR DESCRIPTION
This adds secrets to the job configuration.  Example:

``` yaml
jobs:
  main:
    secrets:
      - NPM_TOKEN
```

Feature: https://github.com/screwdriver-cd/screwdriver/issues/148

Also preventing use of job names with `pr-`
