### PR TITLE
Don't fail when yaml is invalid

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,13 @@ const phaseFlatten = require('./lib/phase/flatten');
 const phaseValidateFunctionality = require('./lib/phase/functional');
 const phaseGeneratePermutations = require('./lib/phase/permutation');
 
-const parseYaml = yaml => (new Promise((resolve) => {
-    const parsedYaml = Yaml.safeLoad(yaml);
-
-    resolve(parsedYaml);
-}));
+/**
+ * Parses a yaml file
+ * @method parseYaml
+ * @param  {String}  yaml Raw yaml
+ * @return {Promise}      resoves POJO containing yaml data
+ */
+const parseYaml = yaml => (new Promise(resolve => resolve(Yaml.safeLoad(yaml))));
 
 /**
  * Parse the configuration from a screwdriver.yaml
@@ -35,5 +37,19 @@ module.exports = function configParser(yaml) {
         .then(doc => ({
             jobs: Hoek.reach(doc, 'jobs'),
             workflow: Hoek.reach(doc, 'workflow')
+        }))
+        .catch(err => ({
+            jobs: {
+                main: {
+                    image: 'alpine',
+                    commands: [{
+                        name: 'config-parse-error',
+                        command: `echo "${err}"; exit 1`
+                    }],
+                    secrets: [],
+                    environment: {}
+                }
+            },
+            workflow: ['main']
         }));
 };

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -126,24 +126,26 @@ function convertSteps(jobs) {
  *  - Merges shared into jobs
  *  - Converts complex environment definitions into JSON strings
  * @method
- * @param  {Object}   parsedDoc Document that went through structural parsing
- * @param  {Function} callback  Function to call when done (err, doc)
+ * @param   {Object}   parsedDoc Document that went through structural parsing
+ * @returns {Promise}
  */
-module.exports = (parsedDoc, callback) => {
-    const doc = parsedDoc;
+module.exports = parsedDoc => (
+    new Promise((resolve) => {
+        const doc = parsedDoc;
 
-    // Shared
-    // Flatten shared into jobs
-    doc.jobs = flattenSharedIntoJobs(parsedDoc.shared, parsedDoc.jobs);
-    delete doc.shared;
+        // Shared
+        // Flatten shared into jobs
+        doc.jobs = flattenSharedIntoJobs(parsedDoc.shared, parsedDoc.jobs);
+        delete doc.shared;
 
-    // Environment
-    // Clean through the job values
-    doc.jobs = cleanComplexEnvironment(doc.jobs);
+        // Environment
+        // Clean through the job values
+        doc.jobs = cleanComplexEnvironment(doc.jobs);
 
-    // Steps
-    // Convert steps into proper expanded output
-    doc.jobs = convertSteps(doc.jobs);
+        // Steps
+        // Convert steps into proper expanded output
+        doc.jobs = convertSteps(doc.jobs);
 
-    callback(null, doc);
-};
+        resolve(doc);
+    })
+);

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -150,7 +150,7 @@ function generateWorkflow(doc) {
  */
 function validateWorkflow(doc) {
     // This happens when user defines main in their workflow
-    const mainCount = (doc.workflow.filter((job) => job === 'main')).length;
+    const mainCount = (doc.workflow.filter(job => job === 'main')).length;
 
     if (mainCount !== 1) {
         return ['Workflow: "main" is implied as the first job and must be excluded'];
@@ -176,21 +176,24 @@ function validateWorkflow(doc) {
  * @method
  * @param  {Object}   flattenedDoc Document that went through flattening
  * @param  {Function} callback     Function to call when done (err, doc)
+ * @param  {Promise}
  */
-module.exports = (flattenedDoc, callback) => {
-    const doc = flattenedDoc;
-    let errors = [];
+module.exports = flattenedDoc => (
+    new Promise((resolve, reject) => {
+        const doc = flattenedDoc;
+        let errors = [];
 
-    // Jobs
-    errors = errors.concat(validateJobSchema(doc));
+        // Jobs
+        errors = errors.concat(validateJobSchema(doc));
 
-    // Workflow
-    doc.workflow = generateWorkflow(doc);
-    errors = errors.concat(validateWorkflow(doc));
+        // Workflow
+        doc.workflow = generateWorkflow(doc);
+        errors = errors.concat(validateWorkflow(doc));
 
-    if (errors.length > 0) {
-        callback(new Error(errors.join('\n')));
-    } else {
-        callback(null, doc);
-    }
-};
+        if (errors.length > 0) {
+            return reject(new Error(errors.join('\n')));
+        }
+
+        return resolve(doc);
+    })
+);

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -9,55 +9,57 @@ const keymbinatorial = require('keymbinatorial');
  * Permutation Phase
  *  - Generate permutations for each job
  * @method
- * @param  {Object}   validatedDoc Document that went through functional validation
- * @param  {Function} callback     Function to call when done (err, doc)
+ * @param   {Object}   validatedDoc Document that went through functional validation
+ * @returns {Promise}
  */
-module.exports = (validatedDoc, callback) => {
-    const doc = validatedDoc;
+module.exports = validatedDoc => (
+    new Promise((resolve) => {
+        const doc = validatedDoc;
 
-    // Generate permutations for each job
-    Object.keys(doc.jobs).forEach((jobName) => {
-        const job = {
-            image: Hoek.reach(doc, `jobs.${jobName}.image`),
-            commands: Hoek.reach(doc, `jobs.${jobName}.commands`),
-            secrets: Hoek.reach(doc, `jobs.${jobName}.secrets`),
-            environment: Hoek.reach(doc, `jobs.${jobName}.environment`, {
+        // Generate permutations for each job
+        Object.keys(doc.jobs).forEach((jobName) => {
+            const job = {
+                image: Hoek.reach(doc, `jobs.${jobName}.image`),
+                commands: Hoek.reach(doc, `jobs.${jobName}.commands`),
+                secrets: Hoek.reach(doc, `jobs.${jobName}.secrets`),
+                environment: Hoek.reach(doc, `jobs.${jobName}.environment`, {
+                    default: {}
+                })
+            };
+            const matrix = Hoek.reach(doc, `jobs.${jobName}.matrix`, {
                 default: {}
-            })
-        };
-        const matrix = Hoek.reach(doc, `jobs.${jobName}.matrix`, {
-            default: {}
-        });
-        const tasks = [];
-        const permutations = keymbinatorial(matrix);
+            });
+            const tasks = [];
+            const permutations = keymbinatorial(matrix);
 
-        permutations.forEach((permutation) => {
-            const newTask = clone(job);
-            const stringPermutation = permutation;
+            permutations.forEach((permutation) => {
+                const newTask = clone(job);
+                const stringPermutation = permutation;
 
-            // Convert all values to string
-            Object.keys(permutation).forEach((varName) => {
-                switch (typeof permutation[varName]) {
-                case 'object':
-                case 'number':
-                case 'boolean':
-                    stringPermutation[varName] = JSON.stringify(permutation[varName]);
-                    break;
-                default:
-                }
+                // Convert all values to string
+                Object.keys(permutation).forEach((varName) => {
+                    switch (typeof permutation[varName]) {
+                    case 'object':
+                    case 'number':
+                    case 'boolean':
+                        stringPermutation[varName] = JSON.stringify(permutation[varName]);
+                        break;
+                    default:
+                    }
+                });
+
+                Object.assign(newTask.environment, stringPermutation);
+
+                // Replace any {{environment-keys}} in the image name with the values
+                // node:{{NODE_VERSION}} with NODE_VERSION=6 becomes node:6
+                newTask.image = TinyTim.tim(newTask.image, newTask.environment);
+
+                tasks.push(newTask);
             });
 
-            Object.assign(newTask.environment, stringPermutation);
-
-            // Replace any {{environment-keys}} in the image name with the values
-            // node:{{NODE_VERSION}} with NODE_VERSION=6 becomes node:6
-            newTask.image = TinyTim.tim(newTask.image, newTask.environment);
-
-            tasks.push(newTask);
+            doc.jobs[jobName] = tasks;
         });
 
-        doc.jobs[jobName] = tasks;
-    });
-
-    callback(null, doc);
-};
+        resolve(doc);
+    })
+);

--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -7,11 +7,19 @@ const SCHEMA_CONFIG = require('screwdriver-data-schema').config.base.config;
  * Structural Phase
  *  - Validate basic structure of the parsed YAML
  * @method
- * @param  {Object}   doc      Direct document from YAML parsing
- * @param  {Function} callback Function to call when done (err, doc)
+ * @param   {Object}   doc      Direct document from YAML parsing
+ * @returns {Promise}
  */
-module.exports = (doc, callback) => {
-    Joi.validate(doc, SCHEMA_CONFIG, {
-        abortEarly: false
-    }, callback);
-};
+module.exports = doc => (
+    new Promise((resolve, reject) => {
+        Joi.validate(doc, SCHEMA_CONFIG, {
+            abortEarly: false
+        }, (err, data) => {
+            if (err) {
+                return reject(err);
+            }
+
+            return resolve(data);
+        });
+    })
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-config-parser",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Node module for parsing screwdriver.yaml configurations",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,6 @@
     "marked-man": "^0.1.5"
   },
   "dependencies": {
-    "async": "^2.0.1",
     "clone": "^2.0.0",
     "hoek": "^4.0.1",
     "joi": "^9.0.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const parser = require('../');
 const fs = require('fs');
@@ -16,161 +17,159 @@ function loadData(name) {
 
 describe('config parser', () => {
     describe('yaml parser', () => {
-        it('returns an error if unparsable yaml', (done) => {
-            parser('foo: :', (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(), /YAMLException:/);
-                done();
-            });
-        });
+        it('returns an error if unparsable yaml', () =>
+            parser('foo: :')
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /YAMLException:/);
+                })
+        );
     });
 
     describe('structure validation', () => {
         describe('overall config', () => {
-            it('returns an error if missing jobs', (done) => {
-                parser('foo: bar', (err) => {
-                    assert.isNotNull(err);
-                    assert.match(err.toString(), /"jobs" is required/);
-                    done();
-                });
-            });
+            it('returns an error if missing jobs', () =>
+                parser('foo: bar')
+                    .catch((err) => {
+                        assert.isNotNull(err);
+                        assert.match(err.toString(), /"jobs" is required/);
+                    })
+            );
         });
 
         describe('jobs', () => {
-            it('returns an error if missing main job', (done) => {
-                parser(loadData('missing-main-job.yaml'), (err) => {
-                    assert.isNotNull(err);
-                    assert.match(err.toString(), /"main" is required/);
-                    done();
-                });
-            });
+            it('returns an error if missing main job', () =>
+                parser(loadData('missing-main-job.yaml'))
+                    .catch((err) => {
+                        assert.isNotNull(err);
+                        assert.match(err.toString(), /"main" is required/);
+                    })
+            );
         });
 
         describe('steps', () => {
-            it('returns an error if not bad named steps', (done) => {
-                parser(loadData('bad-step-name.yaml'), (err) => {
-                    assert.isNotNull(err);
-                    assert.match(err.toString(),
-                        /"foo bar" only supports the following characters A-Z,a-z,0-9,-,_/);
-                    done();
-                });
-            });
+            it('returns an error if not bad named steps', () =>
+                parser(loadData('bad-step-name.yaml'))
+                    .catch((err) => {
+                        assert.isNotNull(err);
+                        assert.match(err.toString(),
+                            /"foo bar" only supports the following characters A-Z,a-z,0-9,-,_/);
+                    })
+            );
         });
 
         describe('environment', () => {
-            it('returns an error if bad environment name', (done) => {
-                parser(loadData('bad-environment-name.yaml'), (err) => {
-                    assert.isNotNull(err);
-                    assert.match(err.toString(), /"foo bar" only supports uppercase letters,/);
-                    done();
-                });
-            });
+            it('returns an error if bad environment name', () =>
+                parser(loadData('bad-environment-name.yaml'))
+                    .catch((err) => {
+                        assert.isNotNull(err);
+                        assert.match(err.toString(), /"foo bar" only supports uppercase letters,/);
+                    })
+            );
         });
 
         describe('matrix', () => {
-            it('returns an error if bad matrix name', (done) => {
-                parser(loadData('bad-matrix-name.yaml'), (err) => {
-                    assert.isNotNull(err);
-                    assert.match(err.toString(), /"foo bar" only supports uppercase letters,/);
-                    done();
-                });
-            });
+            it('returns an error if bad matrix name', () =>
+                parser(loadData('bad-matrix-name.yaml'))
+                    .catch((err) => {
+                        assert.isNotNull(err);
+                        assert.match(err.toString(), /"foo bar" only supports uppercase letters,/);
+                    })
+            );
         });
     });
 
     describe('flatten', () => {
-        it('replaces steps, matrix, image, but merges environment', (done) => {
-            parser(loadData('basic-shared-project.yaml'), (err, data) => {
-                assert.isNull(err);
-                assert.deepEqual(data, JSON.parse(loadData('basic-shared-project.json')));
-                done();
-            });
-        });
+        it('replaces steps, matrix, image, but merges environment', () =>
+            parser(loadData('basic-shared-project.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data, JSON.parse(loadData('basic-shared-project.json')));
+                })
+        );
 
-        it('flattens complex environments', (done) => {
-            parser(loadData('complex-environment.yaml'), (err, data) => {
-                assert.isNull(err);
-                assert.deepEqual(data, JSON.parse(loadData('complex-environment.json')));
-                done();
-            });
-        });
+        it('flattens complex environments', () =>
+            parser(loadData('complex-environment.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data, JSON.parse(loadData('complex-environment.json')));
+                })
+        );
     });
 
     describe('functional', () => {
-        it('returns an error if not enough steps', (done) => {
-            parser(loadData('not-enough-commands.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(), /"steps" must contain at least 1 items/);
-                done();
-            });
-        });
+        it('returns an error if not enough steps', () =>
+            parser(loadData('not-enough-commands.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /"steps" must contain at least 1 items/);
+                })
+        );
 
-        it('returns an error if too many environment variables', (done) => {
-            parser(loadData('too-many-environment.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(), /"environment" can only have 25 environment/);
-                done();
-            });
-        });
+        it('returns an error if too many environment variables', () =>
+            parser(loadData('too-many-environment.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /"environment" can only have 25 environment/);
+                })
+        );
 
-        it('returns an error if too many environment + matrix variables', (done) => {
-            parser(loadData('too-many-matrix.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(), /"environment" and "matrix" can only have a combined/);
-                done();
-            });
-        });
+        it('returns an error if too many environment + matrix variables', () =>
+            parser(loadData('too-many-matrix.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(),
+                        /"environment" and "matrix" can only have a combined/);
+                })
+        );
 
-        it('returns an error if workflow is main is not the first job', (done) => {
-            parser(loadData('workflow-main-not-first.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(), /Workflow: "main" is implied as the first job/);
-                done();
-            });
-        });
+        it('returns an error if workflow is main is not the first job', () =>
+            parser(loadData('workflow-main-not-first.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /Workflow: "main" is implied as the first job/);
+                })
+        );
 
-        it('returns an error if workflow contains different jobs', (done) => {
-            parser(loadData('workflow-wrong-jobs.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(), /Workflow: must contain all the jobs listed/);
-                done();
-            });
-        });
+        it('returns an error if workflow contains different jobs', () =>
+            parser(loadData('workflow-wrong-jobs.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /Workflow: must contain all the jobs listed/);
+                })
+        );
 
-        it('returns an error if matrix is too big', (done) => {
-            parser(loadData('too-big-matrix.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(), /Job "main": "matrix" cannot contain >25 perm/);
-                done();
-            });
-        });
+        it('returns an error if matrix is too big', () =>
+            parser(loadData('too-big-matrix.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(), /Job "main": "matrix" cannot contain >25 perm/);
+                })
+        );
 
-        it('returns an error if using restricted step names', (done) => {
-            parser(loadData('restricted-step-name.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(),
-                    /Job "main": Step "sd-setup": cannot use a restricted prefix "sd-"/);
-                done();
-            });
-        });
+        it('returns an error if using restricted step names', () =>
+            parser(loadData('restricted-step-name.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(),
+                        /Job "main": Step "sd-setup": cannot use a restricted prefix "sd-"/);
+                })
+        );
 
-        it('returns an error if using restricted job names', (done) => {
-            parser(loadData('restricted-job-name.yaml'), (err) => {
-                assert.isNotNull(err);
-                assert.match(err.toString(),
-                    /Job "pr-15": cannot use a restricted prefix "pr-"/);
-                done();
-            });
-        });
+        it('returns an error if using restricted job names', () =>
+            parser(loadData('restricted-job-name.yaml'))
+                .catch((err) => {
+                    assert.isNotNull(err);
+                    assert.match(err.toString(),
+                        /Job "pr-15": cannot use a restricted prefix "pr-"/);
+                })
+        );
     });
 
     describe('permutation', () => {
-        it('generates complex permutations and expands image', (done) => {
-            parser(loadData('node-module.yaml'), (err, data) => {
-                assert.isNull(err);
-                assert.deepEqual(data, JSON.parse(loadData('node-module.json')));
-                done();
-            });
-        });
+        it('generates complex permutations and expands image', () =>
+            parser(loadData('node-module.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data, JSON.parse(loadData('node-module.json')));
+                })
+        );
     });
 });


### PR DESCRIPTION
Converts config-parser to promise interface.
When a parse error occurs, the parser will return a valid config that spits out the error message, and exits with a failure.
