### PR TITLE
fix: incorrect node version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   },
   "engines": {
-    "node": "~6.0.0"
+    "node": "^6.0.0"
   },
   "engine-strict": true,
   "devDependencies": {


### PR DESCRIPTION
I tried yarn to install dependencies for screwdriver and found there is a incorrect dependency.
When I use node 6.8.0, yarn says as below. And it would be right.
```
error screwdriver-config-parser@3.2.2: The engine "node" is incompatible with this module. Expected version "~6.0.0".
```
So I think `^6.0.0` is correct for this restriction.