### PR TITLE
fix: remove stuff for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
-man/

--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ parser(fs.readFileSync('screwdriver.yaml'), (err, pipeline) => {
 });
 ```
 
-Or for usage on the command line see [USAGE.md](./USAGE.md).
-
 ## Testing
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
     "eslint-plugin-import": "^2.0.0",
-    "jenkins-mocha": "^4.0.0",
-    "marked-man": "^0.2.0"
+    "jenkins-mocha": "^4.0.0"
   },
   "dependencies": {
     "clone": "^2.0.0",


### PR DESCRIPTION
The CLI feature seems to removed in #7. These should no longer be necessary.