### PR TITLE
feat(470): Flatten templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,23 +12,24 @@ const phaseGeneratePermutations = require('./lib/phase/permutation');
  * Parses a yaml file
  * @method parseYaml
  * @param  {String}  yaml Raw yaml
- * @return {Promise}      resoves POJO containing yaml data
+ * @return {Promise}      Resolves POJO containing yaml data
  */
 const parseYaml = yaml => (new Promise(resolve => resolve(Yaml.safeLoad(yaml))));
 
 /**
  * Parse the configuration from a screwdriver.yaml
  * @method configParser
- * @param  {String}   yaml      Contents of screwdriver.yaml
- * @param  {Function} callback  Function to call when done (error, { workflow, jobs })
+ * @param  {String}           yaml              Contents of screwdriver.yaml
+ * @param  {TemplateFactory}  templateFactory   Template Factory to get templates
+ * @returns {Promise}
  */
-module.exports = function configParser(yaml) {
+module.exports = function configParser(yaml, templateFactory) {
     // Convert from YAML to JSON
     return parseYaml(yaml)
         // Basic validation
         .then(phaseValidateStructure)
         // Flatten structures
-        .then(phaseFlatten)
+        .then(parsedDoc => phaseFlatten(parsedDoc, templateFactory))
         // Functionality validation
         .then(phaseValidateFunctionality)
         // Generate Permutations

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -2,14 +2,41 @@
 
 const Hoek = require('hoek');
 const clone = require('clone');
+const TEMPLATE_REGEX = require('screwdriver-data-schema').config.regex.FULL_TEMPLATE_NAME;
+const NAME_MATCH = 1;
+const VERSION_MATCH = 3;
+const LABEL_MATCH = 7;
 
 /**
- * Overlays the stuff specified in a specific job on top of the defaults in shared
+ * Merge oldJob into newJob
+ * "oldJob" takes precedence over "newJob". For ex: individual job settings vs shared settings
+ * @param  {Object}   newJob    Job to be merged into. For ex: shared settings
+ * @param  {Object}   oldJob    Job to merge. For ex: individual job settings
+ */
+function merge(newJob, oldJob) {
+    // Intialize new job with default fields (environment, settings, and secrets)
+    newJob.environment = newJob.environment || {};
+    newJob.settings = newJob.settings || {};
+
+    // Merge
+    Object.assign(newJob.environment, oldJob.environment || {});
+    Object.assign(newJob.settings, oldJob.settings || {});
+    newJob.image = oldJob.image || newJob.image;
+
+    // Merge secrets
+    const newSecrets = newJob.secrets || [];
+    const oldSecrets = oldJob.secrets || [];
+
+    newJob.secrets = [...new Set([...newSecrets, ...oldSecrets])];  // remove duplicate
+}
+
+/**
+ * Overlays the fields specified in a specific job on top of the defaults in shared
  *
  * @method flattenSharedIntoJobs
  * @param  {Job}          shared A kind of default Job template
- * @param  {Object}       jobs   List of jobs (name => job)
- * @return {Object}              Updated list of jobs after merging
+ * @param  {Object}       jobs   Object with all the jobs
+ * @return {Object}              New object with jobs after merging
  */
 function flattenSharedIntoJobs(shared, jobs) {
     const newJobs = {};
@@ -19,31 +46,83 @@ function flattenSharedIntoJobs(shared, jobs) {
         const oldJob = clone(jobs[jobName]);
 
         // Replace
-        ['image', 'matrix', 'steps'].forEach((key) => {
+        ['image', 'matrix', 'steps', 'template'].forEach((key) => {
             if (oldJob[key]) {
                 newJob[key] = oldJob[key];
             }
         });
 
-        if (!newJob.environment) {
-            newJob.environment = {};
-        }
-        if (!newJob.secrets) {
-            newJob.secrets = [];
-        }
-        if (!newJob.settings) {
-            newJob.settings = {};
-        }
-
-        // Merge
-        Object.assign(newJob.environment, oldJob.environment || {});
-        Object.assign(newJob.settings, oldJob.settings || {});
-        newJob.secrets = newJob.secrets.concat(oldJob.secrets || []);
-
+        merge(newJob, oldJob);
         newJobs[jobName] = newJob;
     });
 
     return newJobs;
+}
+
+/**
+ * Retrieve template and merge into job config
+ *
+ * @method mergeTemplateIntoJob
+ * @param  {String}           jobName           Job name
+ * @param  {Object}           jobConfig         Job config
+ * @param  {Object}           newJobs           Object with all the jobs
+ * @param  {TemplateFactory}  templateFactory   Template Factory to get templates
+ * @return {Promise}
+ */
+function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
+    const matched = TEMPLATE_REGEX.exec(jobConfig.template);
+    const name = matched[NAME_MATCH];
+    const version = matched[VERSION_MATCH];
+    const label = matched[LABEL_MATCH] ? matched[LABEL_MATCH].slice(1) : '';
+    const oldJob = jobConfig;
+
+    // Try to get the template
+    return templateFactory.getTemplate({ name, version, label })
+        .then((template) => {
+            if (!template) {
+                const labelText = label ? ` with label '${label}'` : '';
+
+                throw new Error(`Template ${name}@${version}${labelText} does not exist`);
+            }
+
+            const newJob = template.config;
+
+            merge(newJob, oldJob);
+            delete newJob.template;
+            newJobs[jobName] = newJob;
+
+            return null;
+        });
+}
+
+/**
+ * Goes through each job and if template is specified, then merge into job config
+ *
+ * @method flattenTemplates
+ * @param  {Object}           jobs              Object with all the jobs
+ * @param  {TemplateFactory}  templateFactory   Template Factory to get templates
+ * @return {Promise}          Resolves to new object with jobs after merging templates
+ */
+function flattenTemplates(jobs, templateFactory) {
+    const newJobs = {};
+    const templates = [];
+
+    // eslint-disable-next-line
+    Object.keys(jobs).forEach((jobName) => {
+        const jobConfig = clone(jobs[jobName]);
+        const templateConfig = jobConfig.template;
+
+        // If template is specified, then merge
+        if (templateConfig) {
+            templates.push(mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory));
+        } else {
+            newJobs[jobName] = jobConfig;   // Otherwise just use jobConfig
+        }
+    });
+
+    // Wait until all promises are resolved
+    return Promise.all(templates)
+        .then(() => newJobs);
 }
 
 /**
@@ -52,8 +131,8 @@ function flattenSharedIntoJobs(shared, jobs) {
  * This is because YAML allows you to define complex structures easily, but our input to the shell
  * is just simple strings (environment variables).
  * @method cleanComplexEnvironment
- * @param  {Object}       jobs   List of jobs (name => job)
- * @return {Object}              Updated list of jobs after cleaning
+ * @param  {Object}       jobs   Object with all the jobs
+ * @return {Object}              Updated object with jobs after cleaning
  */
 function cleanComplexEnvironment(jobs) {
     Object.keys(jobs).forEach((jobName) => {
@@ -86,8 +165,8 @@ function cleanComplexEnvironment(jobs) {
  * The launcher expects it in a consistent format:
  *  - { name: "name", command: "command" }
  * @method convertSteps
- * @param  {Object}       jobs   List of jobs (name => job)
- * @return {Object}              Updated list of jobs after up-converting
+ * @param  {Object}       jobs   Object with all the jobs
+ * @return {Object}              New object with jobs after up-converting
  */
 function convertSteps(jobs) {
     const newJobs = jobs;
@@ -128,28 +207,24 @@ function convertSteps(jobs) {
  * This is where we compress the complexity of the yaml into a format closer to the desired output
  * so that it is easier to validate and iterate on.
  *  - Merges shared into jobs
+ *  - Merges templates into jobs
  *  - Converts complex environment definitions into JSON strings
  * @method
  * @param   {Object}   parsedDoc Document that went through structural parsing
  * @returns {Promise}
  */
-module.exports = parsedDoc => (
-    new Promise((resolve) => {
-        const doc = parsedDoc;
+module.exports = (parsedDoc, templateFactory) => {
+    const doc = parsedDoc;
 
-        // Shared
-        // Flatten shared into jobs
-        doc.jobs = flattenSharedIntoJobs(parsedDoc.shared, parsedDoc.jobs);
-        delete doc.shared;
+    doc.jobs = flattenSharedIntoJobs(parsedDoc.shared, parsedDoc.jobs); // Flatten shared into jobs
+    delete doc.shared;
 
-        // Environment
-        // Clean through the job values
-        doc.jobs = cleanComplexEnvironment(doc.jobs);
+    return flattenTemplates(doc.jobs, templateFactory)    // Flatten templates
+        .then(cleanComplexEnvironment)                    // Clean through the job values
+        .then(convertSteps)                               // Convert steps into proper expanded output
+        .then((jobs) => {                                 // Append flattened jobs and return flattened doc
+            doc.jobs = jobs;
 
-        // Steps
-        // Convert steps into proper expanded output
-        doc.jobs = convertSteps(doc.jobs);
-
-        resolve(doc);
-    })
-);
+            return doc;
+        });
+};

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^2.0.0",
-    "jenkins-mocha": "^4.0.0"
+    "jenkins-mocha": "^4.0.0",
+    "sinon": "^1.17.7",
+    "sinon-as-promised": "^4.0.2"
   },
   "dependencies": {
     "clone": "^2.0.0",
@@ -52,7 +53,7 @@
     "joi": "^10.0.5",
     "js-yaml": "^3.6.1",
     "keymbinatorial": "^1.0.0",
-    "screwdriver-data-schema": "^16.0.1",
+    "screwdriver-data-schema": "^16.5.0",
     "tinytim": "^0.1.1"
   }
 }

--- a/test/data/basic-job-with-template.json
+++ b/test/data/basic-job-with-template.json
@@ -1,0 +1,43 @@
+{
+    "jobs": {
+        "main": [{
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                }
+            ],
+            "environment": {
+                "FOO": "overwritten by job",
+                "BAR": "foo"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            }
+        }],
+      "publish": [{
+          "image": "node:4",
+          "commands": [
+              {
+                  "name": "publish",
+                  "command": "npm publish"
+              }
+          ],
+          "environment": {},
+          "secrets": [],
+          "settings": {}
+      }]
+    },
+    "workflow": [
+        "main",
+        "publish"
+    ]
+}

--- a/test/data/basic-job-with-template.yaml
+++ b/test/data/basic-job-with-template.yaml
@@ -1,0 +1,7 @@
+jobs:
+    main:
+        template: mytemplate@1.2.3
+        environment:
+            FOO: 'overwritten by job'
+    publish:
+        template: yourtemplate@2-stable

--- a/test/data/template-2.json
+++ b/test/data/template-2.json
@@ -1,0 +1,13 @@
+{
+    "name": "yourtemplate",
+    "version": "2",
+    "description": "test template",
+    "maintainer": "foo@bar.com",
+    "labels": ["stable"],
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "publish": "npm publish" }
+        ]
+    }
+}

--- a/test/data/template.json
+++ b/test/data/template.json
@@ -1,0 +1,24 @@
+{
+    "name": "mytemplate",
+    "version": "1.2.3",
+    "description": "test template",
+    "maintainer": "bar@foo.com",
+    "labels": [],
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "install": "npm install" },
+            { "test": "npm test" }
+        ],
+        "environment": {
+            "FOO": "from template",
+            "BAR": "foo"
+        },
+        "secrets": [
+            "GIT_KEY"
+        ],
+        "settings": {
+            "email": "foo@example.com"
+        }
+    }
+}


### PR DESCRIPTION
This merges the template into the job config so that user can use it. Individual job settings take precedence over templates settings. 

~This new version takes in an optional API URL to look up the templates specified in their `screwdriver.yaml`. If they don't specify the API URL and they don't use template in their `screwdriver.yaml`, it still works like before. Debating whether to make this a `major` or `minor` change.~

~Blocked by: this depends on the API endpoint to get template by `name` and `version`. [Third task in the TODO here.](https://github.com/screwdriver-cd/screwdriver/issues/470#issuecomment-285238348)~

Taking in templateFactory to retrieve template instead of making API call. 
Blocked by: 
    - model having the `getTemplate` function
    - data schema: https://github.com/screwdriver-cd/data-schema/pull/115
Related: https://github.com/screwdriver-cd/screwdriver/issues/470