### PR TITLE
feat(473): Parse verbosely defined steps in yaml

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -179,12 +179,20 @@ function convertSteps(jobs) {
         newJobs[jobName].commands = steps.map((step, index) => {
             let name;
             let command;
+            let alwaysRun = false;
 
             switch (typeof step) {
             case 'object':
-                name = Object.keys(step).pop();
-                command = step[name];
-                break;
+                if (Object.keys(step).length === 1) {
+                    name = Object.keys(step).pop();
+                    command = step[name];
+                    break;
+                } else {
+                    name = step.name;
+                    command = step.command;
+                    alwaysRun = step.alwaysRun || false;
+                    break;
+                }
 
             case 'string':
                 name = `step-${index + 1}`;
@@ -194,7 +202,7 @@ function convertSteps(jobs) {
             default:
             }
 
-            return { name, command };
+            return { name, command, alwaysRun };
         });
     });
 

--- a/test/data/basic-job-with-template.json
+++ b/test/data/basic-job-with-template.json
@@ -5,11 +5,13 @@
             "commands": [
                 {
                     "name": "install",
-                    "command": "npm install"
+                    "command": "npm install",
+                    "alwaysRun": false
                 },
                 {
                     "name": "test",
-                    "command": "npm test"
+                    "command": "npm test",
+                    "alwaysRun": false
                 }
             ],
             "environment": {
@@ -28,7 +30,8 @@
           "commands": [
               {
                   "name": "publish",
-                  "command": "npm publish"
+                  "command": "npm publish",
+                  "alwaysRun": false
               }
           ],
           "environment": {},

--- a/test/data/basic-shared-project.json
+++ b/test/data/basic-shared-project.json
@@ -6,15 +6,18 @@
                 "commands": [
                     {
                         "name": "install",
-                        "command": "npm install"
+                        "command": "npm install",
+                        "alwaysRun": false
                     },
                     {
                         "name": "test",
-                        "command": "npm test"
+                        "command": "npm test",
+                        "alwaysRun": false
                     },
                     {
                         "name": "publish",
-                        "command": "npm publish"
+                        "command": "npm publish",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -35,15 +38,18 @@
                 "commands": [
                     {
                         "name": "install",
-                        "command": "npm install"
+                        "command": "npm install",
+                        "alwaysRun": false
                     },
                     {
                         "name": "test",
-                        "command": "npm test"
+                        "command": "npm test",
+                        "alwaysRun": false
                     },
                     {
                         "name": "publish",
-                        "command": "npm publish"
+                        "command": "npm publish",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -66,7 +72,8 @@
                 "commands": [
                     {
                         "name": "step-1",
-                        "command": "hostname"
+                        "command": "hostname",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -88,7 +95,8 @@
                 "commands": [
                     {
                         "name": "step-1",
-                        "command": "hostname"
+                        "command": "hostname",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -110,7 +118,8 @@
                 "commands": [
                     {
                         "name": "step-1",
-                        "command": "hostname"
+                        "command": "hostname",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -132,7 +141,8 @@
                 "commands": [
                     {
                         "name": "step-1",
-                        "command": "hostname"
+                        "command": "hostname",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {

--- a/test/data/complex-environment.json
+++ b/test/data/complex-environment.json
@@ -6,7 +6,8 @@
                 "commands": [
                     {
                         "name": "install",
-                        "command": "npm install"
+                        "command": "npm install",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {

--- a/test/data/node-module.json
+++ b/test/data/node-module.json
@@ -6,11 +6,13 @@
                 "commands": [
                     {
                         "name": "init",
-                        "command": "npm install"
+                        "command": "npm install",
+                        "alwaysRun": false
                     },
                     {
                         "name": "test",
-                        "command": "npm test"
+                        "command": "npm test",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -25,11 +27,13 @@
                 "commands": [
                     {
                         "name": "init",
-                        "command": "npm install"
+                        "command": "npm install",
+                        "alwaysRun": false
                     },
                     {
                         "name": "test",
-                        "command": "npm test"
+                        "command": "npm test",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -44,11 +48,13 @@
                 "commands": [
                     {
                         "name": "init",
-                        "command": "npm install"
+                        "command": "npm install",
+                        "alwaysRun": false
                     },
                     {
                         "name": "test",
-                        "command": "npm test"
+                        "command": "npm test",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {
@@ -65,15 +71,18 @@
                 "commands": [
                     {
                         "name": "bump",
-                        "command": "npm run bump"
+                        "command": "npm run bump",
+                        "alwaysRun": false
                     },
                     {
                         "name": "publish",
-                        "command": "npm publish --tag $NODE_TAG"
+                        "command": "npm publish --tag $NODE_TAG",
+                        "alwaysRun": false
                     },
                     {
                         "name": "tag",
-                        "command": "git push origin --tags"
+                        "command": "git push origin --tags",
+                        "alwaysRun": false
                     }
                 ],
                 "environment": {

--- a/test/data/verbose-project.json
+++ b/test/data/verbose-project.json
@@ -1,0 +1,30 @@
+{
+  "jobs": {
+    "main": [{
+      "image": "node:4",
+      "commands": [
+        {
+          "name": "install",
+          "command": "npm install",
+          "alwaysRun": true
+        },
+        {
+          "name": "test",
+          "command": "npm test",
+          "alwaysRun": true
+        },
+        {
+          "name": "publish",
+          "command": "npm publish",
+          "alwaysRun": false
+        }
+    ],
+      "environment": {},
+      "secrets": [],
+      "settings": {}
+  }]
+},
+  "workflow": [
+      "main"
+  ]
+}

--- a/test/data/verbose-project.yaml
+++ b/test/data/verbose-project.yaml
@@ -1,0 +1,13 @@
+jobs:
+    main:
+        image: node:4
+        steps:
+            - name: install
+              command: npm install
+              alwaysRun: true
+            - name: test
+              command: npm test
+              alwaysRun: true
+            - name: publish
+              command: npm publish
+              alwaysRun: false

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -102,6 +102,13 @@ describe('config parser', () => {
                 })
         );
 
+        it('flattens verbosely defined steps', () =>
+            parser(loadData('verbose-project.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data, JSON.parse(loadData('verbose-project.json')));
+                })
+        );
+
         describe('templates', () => {
             const firstTemplate = JSON.parse(loadData('template.json'));
             const secondTemplate = JSON.parse(loadData('template-2.json'));


### PR DESCRIPTION
Allow users to add an `alwaysRun` flag to the steps in their `screwdriver.yaml`. For example:

```yaml
jobs:
    main:
        image: node:4
        steps:
            - name: install
              command: npm install
              alwaysRun: true
            - name: test
              command: npm test
              alwaysRun: true
            - name: publish
              command: npm publish
              alwaysRun: false
```

This will allow the `alwaysRun` feature (https://github.com/screwdriver-cd/screwdriver/issues/473)