### PR TITLE
fix(599): Throw error when screwdriver.yaml does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,15 @@ const phaseGeneratePermutations = require('./lib/phase/permutation');
  * @param  {String}  yaml Raw yaml
  * @return {Promise}      Resolves POJO containing yaml data
  */
-const parseYaml = yaml => (new Promise(resolve => resolve(Yaml.safeLoad(yaml))));
+function parseYaml(yaml) {
+    // If no yaml exists, throw error
+    if (!yaml) {
+        return Promise.reject('screwdriver.yaml does not exist. Please ' +
+        'create a screwdriver.yaml and try to rerun your build.');
+    }
+
+    return new Promise(resolve => resolve(Yaml.safeLoad(yaml)));
+}
 
 /**
  * Parse the configuration from a screwdriver.yaml

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
   "engine-strict": true,
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.18.0",
-    "eslint-config-screwdriver": "^2.0.0",
+    "eslint": "^3.2.2",
+    "eslint-config-screwdriver": "^2.1.4",
     "jenkins-mocha": "^4.0.0",
-    "sinon": "^2.0.0"
+    "sinon": "^2.3.4"
   },
   "dependencies": {
     "clone": "^2.0.0",
     "hoek": "^4.0.1",
     "joi": "^10.0.5",
-    "js-yaml": "^3.6.1",
+    "js-yaml": "^3.8.3",
     "keymbinatorial": "^1.0.0",
     "screwdriver-data-schema": "^16.5.0",
     "tinytim": "^0.1.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,6 +20,22 @@ function loadData(name) {
 
 describe('config parser', () => {
     describe('yaml parser', () => {
+        it('returns an error if yaml does not exist', () => {
+            const YAMLMISSING = /screwdriver.yaml does not exist/;
+
+            return parser('')
+                .then((data) => {
+                    assert.deepEqual(data.workflow, ['main']);
+                    assert.strictEqual(data.jobs.main[0].image, 'node:6');
+                    assert.deepEqual(data.jobs.main[0].image, 'node:6');
+                    assert.deepEqual(data.jobs.main[0].secrets, []);
+                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
+                    assert.match(data.jobs.main[0].commands[0].command, YAMLMISSING);
+                    assert.match(data.errors[0], YAMLMISSING);
+                });
+        });
+
         it('returns an error if unparsable yaml', () =>
             parser('foo: :')
                 .then((data) => {


### PR DESCRIPTION
Add logic to check if screwdriver.yaml exists. If it doesn't, throw an error.

Related to https://github.com/screwdriver-cd/screwdriver/issues/599
https://github.com/screwdriver-cd/screwdriver/issues/593