### PR TITLE
feat(423): Allow parsing of description in config-parser

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -48,7 +48,7 @@ function flattenSharedIntoJobs(shared, jobs) {
         const oldJob = clone(jobs[jobName]);
 
         // Replace
-        ['image', 'matrix', 'steps', 'template'].forEach((key) => {
+        ['image', 'matrix', 'steps', 'template', 'description'].forEach((key) => {
             if (oldJob[key]) {
                 newJob[key] = oldJob[key];
             }

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -22,16 +22,21 @@ module.exports = validatedDoc => (
                 annotations: Hoek.reach(doc, `jobs.${jobName}.annotations`, {
                     default: {}
                 }),
-                image: Hoek.reach(doc, `jobs.${jobName}.image`),
                 commands: Hoek.reach(doc, `jobs.${jobName}.commands`),
-                secrets: Hoek.reach(doc, `jobs.${jobName}.secrets`),
                 environment: Hoek.reach(doc, `jobs.${jobName}.environment`, {
                     default: {}
                 }),
+                image: Hoek.reach(doc, `jobs.${jobName}.image`),
+                secrets: Hoek.reach(doc, `jobs.${jobName}.secrets`),
                 settings: Hoek.reach(doc, `jobs.${jobName}.settings`, {
                     default: {}
                 })
             };
+
+            if (doc.jobs[jobName].description !== undefined) {
+                job.description = doc.jobs[jobName].description;
+            }
+
             const matrix = Hoek.reach(doc, `jobs.${jobName}.matrix`, {
                 default: {}
             });

--- a/test/data/basic-job-with-description.yaml
+++ b/test/data/basic-job-with-description.yaml
@@ -1,0 +1,9 @@
+shared:
+    image: node:4
+
+jobs:
+    main:
+        description: "This is a description"
+        steps:
+            - hello: "echo hi world"
+            - maybe: "which asdfzxcvasdfqwer1234"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -271,6 +271,15 @@ describe('config parser', () => {
                     assert.deepEqual(data, JSON.parse(loadData('pipeline-annotations.json')));
                 })
         );
+
+        it('allows a description key', () =>
+            parser(loadData('basic-job-with-description.yaml'))
+                .then((data) => {
+                    assert.isDefined(data.jobs.main[0].description);
+                    assert.equal(data.jobs.main[0].description,
+                        'This is a description');
+                })
+        );
     });
 
     describe('permutation', () => {


### PR DESCRIPTION
- Add basic job with description yaml file to test/data
- Allow parsing of description by modifying flatten and permutation
  phases