### PR TITLE
feat: Add support for wrapping steps in template

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -10,10 +10,11 @@ const LABEL_MATCH = 7;
 /**
  * Merge oldJob into newJob
  * "oldJob" takes precedence over "newJob". For ex: individual job settings vs shared settings
- * @param  {Object}   newJob    Job to be merged into. For ex: shared settings
- * @param  {Object}   oldJob    Job to merge. For ex: individual job settings
+ * @param  {Object}   newJob        Job to be merged into. For ex: shared settings
+ * @param  {Object}   oldJob        Job to merge. For ex: individual job settings
+ * @param  {Boolean}  fromTemplate  Whether this is merged from template. If true, perform extra actions such as wrapping.
  */
-function merge(newJob, oldJob) {
+function merge(newJob, oldJob, fromTemplate) {
     // Intialize new job with default fields (environment, settings, and secrets)
     newJob.annotations = newJob.annotations || {};
     newJob.environment = newJob.environment || {};
@@ -30,6 +31,42 @@ function merge(newJob, oldJob) {
     const oldSecrets = oldJob.secrets || [];
 
     newJob.secrets = [...new Set([...newSecrets, ...oldSecrets])];  // remove duplicate
+
+    if (fromTemplate && oldJob.steps) {
+        let stepName;
+        let preStepName;
+        let postStepName;
+        const mergedSteps = [];
+
+        // convert steps from oldJob from array to object for faster lookup
+        const oldSteps = oldJob.steps.reduce((obj, item) => {
+            const key = Object.keys(item)[0];
+
+            obj[key] = item[key];
+
+            return obj;
+        }, {});
+
+        for (let i = 0; i < newJob.steps.length; i += 1) {
+            stepName = Object.keys(newJob.steps[i])[0];
+            preStepName = `pre${stepName}`;
+            postStepName = `post${stepName}`;
+
+            // add pre-step
+            if (oldSteps[preStepName]) {
+                mergedSteps.push({ [preStepName]: oldSteps[preStepName] });
+            }
+
+            mergedSteps.push(newJob.steps[i]);
+
+            // add post-step
+            if (oldSteps[postStepName]) {
+                mergedSteps.push({ [postStepName]: oldSteps[postStepName] });
+            }
+        }
+
+        newJob.steps = mergedSteps;
+    }
 }
 
 /**
@@ -89,7 +126,7 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
 
             const newJob = template.config;
 
-            merge(newJob, oldJob);
+            merge(newJob, oldJob, true);
             delete newJob.template;
             newJobs[jobName] = newJob;
 

--- a/test/data/basic-job-with-template-wrapped-steps.json
+++ b/test/data/basic-job-with-template-wrapped-steps.json
@@ -1,0 +1,40 @@
+{
+    "annotations": {},
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "postinstall",
+                    "command": "echo post-install"
+                },
+                {
+                    "name": "pretest",
+                    "command": "echo pre-test"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                }
+            ],
+            "environment": {
+                "FOO": "from template",
+                "BAR": "foo"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            }
+        }]
+    },
+    "workflow": [
+        "main"
+    ]
+}

--- a/test/data/basic-job-with-template-wrapped-steps.yaml
+++ b/test/data/basic-job-with-template-wrapped-steps.yaml
@@ -1,0 +1,6 @@
+jobs:
+    main:
+        template: mytemplate@1.2.3
+        steps:
+            - pretest: echo pre-test
+            - postinstall: echo post-install

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -142,8 +142,6 @@ describe('config parser', () => {
         );
 
         describe('templates', () => {
-            const firstTemplate = JSON.parse(loadData('template.json'));
-            const secondTemplate = JSON.parse(loadData('template-2.json'));
             const templateFactoryMock = {
                 getTemplate: sinon.stub()
             };
@@ -157,24 +155,32 @@ describe('config parser', () => {
                 version: '2',
                 label: 'stable'
             };
+            let firstTemplate;
+            let secondTemplate;
 
-            it('flattens templates sucessfully', () => {
+            beforeEach(() => {
+                firstTemplate = JSON.parse(loadData('template.json'));
+                secondTemplate = JSON.parse(loadData('template-2.json'));
                 templateFactoryMock.getTemplate.withArgs(firstTemplateConfig)
                     .resolves(firstTemplate);
                 templateFactoryMock.getTemplate.withArgs(secondTemplateConfig)
                     .resolves(secondTemplate);
-
-                return parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
-                  .then((data) => {
-                      assert.deepEqual(data, JSON.parse(loadData('basic-job-with-template.json')));
-                  });
             });
 
+            it('flattens templates sucessfully', () =>
+                parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
+                .then(data => assert.deepEqual(
+                    data, JSON.parse(loadData('basic-job-with-template.json'))))
+            );
+
+            it('flattens templates with wrapped steps ', () =>
+                parser(loadData('basic-job-with-template-wrapped-steps.yaml'), templateFactoryMock)
+                .then(data => assert.deepEqual(
+                    data, JSON.parse(loadData('basic-job-with-template-wrapped-steps.json'))))
+            );
+
             it('returns error if template does not exist', () => {
-                templateFactoryMock.getTemplate.withArgs(firstTemplateConfig)
-                    .resolves(null);
-                templateFactoryMock.getTemplate.withArgs(secondTemplateConfig)
-                    .resolves(secondTemplate);
+                templateFactoryMock.getTemplate.withArgs(firstTemplateConfig).resolves(null);
 
                 return parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
                     .then((data) => {
@@ -186,16 +192,12 @@ describe('config parser', () => {
             });
 
             it('returns error if template (with label) does not exist', () => {
-                templateFactoryMock.getTemplate.withArgs(firstTemplateConfig)
-                    .resolves(firstTemplate);
-                templateFactoryMock.getTemplate.withArgs(secondTemplateConfig)
-                    .resolves(null);
+                templateFactoryMock.getTemplate.withArgs(secondTemplateConfig).resolves(null);
 
                 return parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
-                    .then((data) => {
+                    .then(data =>
                         assert.match(data.jobs.main[0].commands[0].command,
-                            /Template yourtemplate@2 with label 'stable' does not exist/);
-                    });
+                            /Template yourtemplate@2 with label 'stable' does not exist/));
             });
         });
     });


### PR DESCRIPTION
Allow wrapping around steps inside template. 
**Example:**
Inside template:
```yaml
   steps: 
       - test: echo test
       - publish: echo publish
```

Inside user's screwdriver.yaml:
```yaml
main:
   template: mytemplate@1
   steps: 
       - pretest: echo hello
       - posttest: echo goodbye
```

Translates into: 
```yaml
   steps:
       - pretest: echo hello
       - test: echo test
       - posttest: echo goodbye
       - publish: echo publish
```

Question: If the step `test` doesn't exist, should we error, or should we ignore it? With this implementation, it will ignore it. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/616