### PR TITLE
feat: support overriding steps for templates

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -57,7 +57,12 @@ function merge(newJob, oldJob, fromTemplate) {
                 mergedSteps.push({ [preStepName]: oldSteps[preStepName] });
             }
 
-            mergedSteps.push(newJob.steps[i]);
+            // override step
+            if (oldSteps[stepName]) {
+                mergedSteps.push({ [stepName]: oldSteps[stepName] });
+            } else {
+                mergedSteps.push(newJob.steps[i]);
+            }
 
             // add post-step
             if (oldSteps[postStepName]) {

--- a/test/data/basic-job-with-template-override-steps.json
+++ b/test/data/basic-job-with-template-override-steps.json
@@ -1,0 +1,36 @@
+{
+    "annotations": {},
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "pretest",
+                    "command": "echo pre-test"
+                },
+                {
+                    "name": "test",
+                    "command": "echo 'my job is overriding this step'"
+                }
+            ],
+            "environment": {
+                "FOO": "from template",
+                "BAR": "foo"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            }
+        }]
+    },
+    "workflow": [
+        "main"
+    ]
+}

--- a/test/data/basic-job-with-template-override-steps.yaml
+++ b/test/data/basic-job-with-template-override-steps.yaml
@@ -1,0 +1,6 @@
+jobs:
+    main:
+        template: mytemplate@1.2.3
+        steps:
+            - pretest: echo pre-test
+            - test: echo 'my job is overriding this step'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -179,6 +179,12 @@ describe('config parser', () => {
                     data, JSON.parse(loadData('basic-job-with-template-wrapped-steps.json'))))
             );
 
+            it('flattens templates with job steps ', () =>
+                parser(loadData('basic-job-with-template-override-steps.yaml'), templateFactoryMock)
+                .then(data => assert.deepEqual(
+                    data, JSON.parse(loadData('basic-job-with-template-override-steps.json'))))
+            );
+
             it('returns error if template does not exist', () => {
                 templateFactoryMock.getTemplate.withArgs(firstTemplateConfig).resolves(null);
 


### PR DESCRIPTION
Allows override steps for templates

```
main:
   template: mytemplate@1
   steps: 
       - publish: echo not publishing
```

Translate into:
```
   steps:
       - test: echo test
       - publish: echo not publishing
```

Related: https://github.com/screwdriver-cd/screwdriver/issues/616