### PR TITLE
feat(616): support tag in templates [2]

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -2,10 +2,6 @@
 
 const Hoek = require('hoek');
 const clone = require('clone');
-const TEMPLATE_REGEX = require('screwdriver-data-schema').config.regex.FULL_TEMPLATE_NAME;
-const NAME_MATCH = 1;
-const VERSION_MATCH = 3;
-const LABEL_MATCH = 7;
 
 /**
  * Merge oldJob into newJob
@@ -114,19 +110,13 @@ function flattenSharedIntoJobs(shared, jobs) {
  * @return {Promise}
  */
 function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
-    const matched = TEMPLATE_REGEX.exec(jobConfig.template);
-    const name = matched[NAME_MATCH];
-    const version = matched[VERSION_MATCH];
-    const label = matched[LABEL_MATCH] ? matched[LABEL_MATCH].slice(1) : '';
     const oldJob = jobConfig;
 
     // Try to get the template
-    return templateFactory.getTemplate({ name, version, label })
+    return templateFactory.getTemplate(jobConfig.template)
         .then((template) => {
             if (!template) {
-                const labelText = label ? ` with label '${label}'` : '';
-
-                throw new Error(`Template ${name}@${version}${labelText} does not exist`);
+                throw new Error(`Template ${jobConfig.template} does not exist`);
             }
 
             const newJob = template.config;

--- a/test/data/basic-job-with-template.yaml
+++ b/test/data/basic-job-with-template.yaml
@@ -4,4 +4,4 @@ jobs:
         environment:
             FOO: 'overwritten by job'
     publish:
-        template: yourtemplate@2-stable
+        template: yourtemplate@2

--- a/test/data/template-2.json
+++ b/test/data/template-2.json
@@ -3,7 +3,7 @@
     "version": "2",
     "description": "test template",
     "maintainer": "foo@bar.com",
-    "labels": ["stable"],
+    "labels": [],
     "config": {
         "image": "node:4",
         "steps": [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,25 +145,15 @@ describe('config parser', () => {
             const templateFactoryMock = {
                 getTemplate: sinon.stub()
             };
-            const firstTemplateConfig = {
-                name: 'mytemplate',
-                version: '1.2.3',
-                label: ''
-            };
-            const secondTemplateConfig = {
-                name: 'yourtemplate',
-                version: '2',
-                label: 'stable'
-            };
             let firstTemplate;
             let secondTemplate;
 
             beforeEach(() => {
                 firstTemplate = JSON.parse(loadData('template.json'));
                 secondTemplate = JSON.parse(loadData('template-2.json'));
-                templateFactoryMock.getTemplate.withArgs(firstTemplateConfig)
+                templateFactoryMock.getTemplate.withArgs('mytemplate@1.2.3')
                     .resolves(firstTemplate);
-                templateFactoryMock.getTemplate.withArgs(secondTemplateConfig)
+                templateFactoryMock.getTemplate.withArgs('yourtemplate@2')
                     .resolves(secondTemplate);
             });
 
@@ -186,7 +176,7 @@ describe('config parser', () => {
             );
 
             it('returns error if template does not exist', () => {
-                templateFactoryMock.getTemplate.withArgs(firstTemplateConfig).resolves(null);
+                templateFactoryMock.getTemplate.withArgs('mytemplate@1.2.3').resolves(null);
 
                 return parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
                     .then((data) => {
@@ -195,15 +185,6 @@ describe('config parser', () => {
                         assert.match(data.errors[0],
                             /Template mytemplate@1.2.3 does not exist/);
                     });
-            });
-
-            it('returns error if template (with label) does not exist', () => {
-                templateFactoryMock.getTemplate.withArgs(secondTemplateConfig).resolves(null);
-
-                return parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
-                    .then(data =>
-                        assert.match(data.jobs.main[0].commands[0].command,
-                            /Template yourtemplate@2 with label 'stable' does not exist/));
             });
         });
     });


### PR DESCRIPTION
### Objective
We want to allow fetching the template based on tag. 

### Context
The `mergeTemplateIntoJob` will now call `getTemplate(name)` instead of `getTemplate({name, version, tag}`. The logic of handling `version` and `tag` will be pushed to the model. 

This PR is blocked on the model change. 

`label` is not in used now. We will revisit `label` when we get to annotations/keywords

Related: https://github.com/screwdriver-cd/screwdriver/issues/616