### PR TITLE
fix: add workflowGraph to parsed config with err

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,17 @@ module.exports = function configParser(yaml, templateFactory) {
                 }]
             },
             workflow: ['main'], // remove this after we stop supporting workflow
+            workflowGraph: {
+                nodes: [
+                    { name: '~pr' },
+                    { name: '~commit' },
+                    { name: 'main' }
+                ],
+                edges: [
+                    { src: '~pr', dest: 'main' },
+                    { src: '~commit', dest: 'main' }
+                ]
+            },
             errors: [err.toString()]
         }));
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,6 +26,17 @@ describe('config parser', () => {
             return parser('')
                 .then((data) => {
                     assert.deepEqual(data.workflow, ['main']);
+                    assert.deepEqual(data.workflowGraph, {
+                        nodes: [
+                            { name: '~pr' },
+                            { name: '~commit' },
+                            { name: 'main' }
+                        ],
+                        edges: [
+                            { src: '~pr', dest: 'main' },
+                            { src: '~commit', dest: 'main' }
+                        ]
+                    });
                     assert.strictEqual(data.jobs.main[0].image, 'node:6');
                     assert.deepEqual(data.jobs.main[0].image, 'node:6');
                     assert.deepEqual(data.jobs.main[0].secrets, []);


### PR DESCRIPTION
All parsed config should have the workflowGraph. That's what we are going to use to represent event.

Add `workflowGraph` to parsed config with err.