### PR TITLE
fix(723): requires main job for only legacy config

### DIFF
--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -160,13 +160,20 @@ function generateWorkflowGraph(doc) {
 
 /**
  * Ensure the workflow is a valid one
- *  - Contains all defined jobs (no extra or missing)
+ *  - Main job exists
  *  - Main is first
+ *  - Contains all defined jobs (no extra or missing)
  * @method validateWorkflow
  * @param  {Object}          doc Document that went through flattening
  * @return {Array}               List of errors
  */
 function validateWorkflow(doc) {
+    const hasMain = Object.keys(doc.jobs).includes('main');
+
+    if (!hasMain) {
+        return ['Jobs: "main" is required'];
+    }
+
     // This happens when user defines main in their workflow
     const mainCount = (doc.workflow.filter(job => job === 'main')).length;
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "joi": "^10.0.5",
     "js-yaml": "^3.8.3",
     "keymbinatorial": "^1.0.0",
-    "screwdriver-data-schema": "^18.0.0",
+    "screwdriver-data-schema": "^18.6.0",
     "screwdriver-workflow-parser": "^1.0.0",
     "tinytim": "^0.1.1"
   }

--- a/test/data/missing-main-job-with-requires.yaml
+++ b/test/data/missing-main-job-with-requires.yaml
@@ -1,0 +1,8 @@
+jobs:
+    foobar:
+        image: node:6
+        requires: ~commit
+        steps:
+            - install: npm install
+            - test: npm test
+            - publish: npm publish

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -104,11 +104,18 @@ describe('config parser', () => {
         });
 
         describe('jobs', () => {
-            it('returns an error if missing main job', () =>
+            it('returns an error if missing main job for legacy config', () =>
                 parser(loadData('missing-main-job.yaml'))
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command, /"main" is required/);
                         assert.match(data.errors[0], /"main" is required/);
+                    })
+            );
+
+            it('Do not return error if missing main job for new config', () =>
+                parser(loadData('missing-main-job-with-requires.yaml'))
+                    .then((data) => {
+                        assert.notOk(data.errors);
                     })
             );
         });


### PR DESCRIPTION
We will remove `main` as required from data-schema.
Add an extra check here to validate that for legacy config. 

Blocked by https://github.com/screwdriver-cd/data-schema/pull/188