### PR TITLE
fix: increase ENV limit

### DIFF
--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -7,7 +7,7 @@ const WorkflowParser = require('screwdriver-workflow-parser');
 
 // Actual environment size is limited by space, not quantity.
 // We do this to force sd.yaml to be simpler.
-const MAX_ENVIRONMENT_VARS = 25;
+const MAX_ENVIRONMENT_VARS = 35;
 // If they are trying to execute >25 permutations,
 // maybe there is a better way to accomplish their goal.
 const MAX_PERMUTATIONS = 25;

--- a/test/data/too-many-environment.yaml
+++ b/test/data/too-many-environment.yaml
@@ -31,3 +31,13 @@ jobs:
             VAR24: 24
             VAR25: 25
             VAR26: 26
+            VAR27: 27
+            VAR28: 28
+            VAR29: 29
+            VAR30: 30
+            VAR31: 31
+            VAR32: 32
+            VAR33: 33
+            VAR34: 34
+            VAR35: 35
+            VAR36: 36

--- a/test/data/too-many-matrix.yaml
+++ b/test/data/too-many-matrix.yaml
@@ -33,3 +33,13 @@ jobs:
             VAR22: 22
             VAR23: 23
             VAR24: 24
+            VAR25: 25
+            VAR26: 26
+            VAR27: 27
+            VAR28: 28
+            VAR29: 29
+            VAR30: 30
+            VAR31: 31
+            VAR32: 32
+            VAR33: 33
+            VAR34: 34

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -250,7 +250,7 @@ describe('config parser', () => {
             parser(loadData('too-many-environment.yaml'))
                 .then((data) => {
                     assert.match(data.jobs.main[0].commands[0].command,
-                        /"environment" can only have 25 environment/);
+                        /"environment" can only have 35 environment/);
                 })
         );
 


### PR DESCRIPTION
Increasing the Environment Variable limit since some jobs might need more than 25 environment variables. 

Based on @Renaud's request