### PR TITLE
fix: semantic-release-node8 does not work yet

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:6
 
 jobs:
     main:
@@ -11,7 +11,7 @@ jobs:
             - ~commit
 
     publish:
-        template: screwdriver-cd/semantic-release-node8
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
Switching back to node6