### PR TITLE
fix: add env variables to indicate template name and version

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -133,6 +133,13 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
             }
 
             const newJob = template.config;
+            const environment = newJob.environment || {};
+
+            // Inject template version and name to env
+            newJob.environment = Hoek.merge(environment, {
+                SD_TEMPLATE_VERSION: template.version,
+                SD_TEMPLATE_NAME: template.name
+            });
 
             merge(newJob, oldJob, true);
             delete newJob.template;

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -11,6 +11,8 @@ const MAX_ENVIRONMENT_VARS = 35;
 // If they are trying to execute >25 permutations,
 // maybe there is a better way to accomplish their goal.
 const MAX_PERMUTATIONS = 25;
+// Env that created by screwdriver instead of user
+const SDEnv = ['SD_TEMPLATE_NAME', 'SD_TEMPLATE_VERSION'];
 
 /**
  * Make sure the Matrix they specified is valid
@@ -28,7 +30,8 @@ function validateJobMatrix(job, prefix) {
     const environment = Hoek.reach(job, 'environment', {
         default: {}
     });
-    const environmentSize = Object.keys(matrix).length + Object.keys(environment).length;
+    const userEnv = Object.keys(environment).filter(key => !SDEnv.includes(key));
+    const environmentSize = Object.keys(matrix).length + userEnv.length;
 
     if (environmentSize > MAX_ENVIRONMENT_VARS) {
         errors.push(`${prefix}: "environment" and "matrix" can only have a combined ` +
@@ -89,15 +92,14 @@ function validateJobSchema(doc) {
         .keys({
             commands: Joi.array().min(1).required(),
             image: Joi.string().required(),
-            environment: Joi.object().max(MAX_ENVIRONMENT_VARS).default({})
+            environment: Joi.object().default({})
         })
         .unknown(true)
         // Add documentation
         .options({
             language: {
                 object: {
-                    min: 'requires at least one step',
-                    max: `can only have ${MAX_ENVIRONMENT_VARS} environment variables defined`
+                    min: 'requires at least one step'
                 }
             }
         });
@@ -110,6 +112,16 @@ function validateJobSchema(doc) {
             Joi.attempt(doc.jobs[jobName], SCHEMA_JOB, prefix);
         } catch (err) {
             errors.push(err.message);
+        }
+
+        const environment = Hoek.reach(doc.jobs[jobName], 'environment', {
+            default: {}
+        });
+        const userEnv = Object.keys(environment).filter(key => !SDEnv.includes(key));
+
+        if (userEnv.length > MAX_ENVIRONMENT_VARS) {
+            // eslint-disable-next-line max-len
+            errors.push(`"environment" can only have ${MAX_ENVIRONMENT_VARS} environment variables defined`);
         }
 
         // Check special prefixes

--- a/test/data/basic-job-with-template-override-steps.json
+++ b/test/data/basic-job-with-template-override-steps.json
@@ -20,7 +20,9 @@
             ],
             "environment": {
                 "FOO": "from template",
-                "BAR": "foo"
+                "BAR": "foo",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_VERSION": "1.2.3"
             },
             "secrets": [
                 "GIT_KEY"

--- a/test/data/basic-job-with-template-wrapped-steps.json
+++ b/test/data/basic-job-with-template-wrapped-steps.json
@@ -24,7 +24,9 @@
             ],
             "environment": {
                 "FOO": "from template",
-                "BAR": "foo"
+                "BAR": "foo",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_VERSION": "1.2.3"
             },
             "secrets": [
                 "GIT_KEY"

--- a/test/data/basic-job-with-template.json
+++ b/test/data/basic-job-with-template.json
@@ -16,7 +16,9 @@
             ],
             "environment": {
                 "FOO": "overwritten by job",
-                "BAR": "foo"
+                "BAR": "foo",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_VERSION": "1.2.3"
             },
             "secrets": [
                 "GIT_KEY"
@@ -34,7 +36,10 @@
                   "command": "npm publish"
               }
           ],
-          "environment": {},
+          "environment": {
+              "SD_TEMPLATE_NAME": "yourtemplate",
+              "SD_TEMPLATE_VERSION": "2"
+          },
           "secrets": [],
           "settings": {}
       }]

--- a/test/data/environment-with-SD-variable.yaml
+++ b/test/data/environment-with-SD-variable.yaml
@@ -1,0 +1,43 @@
+jobs:
+    main:
+        steps:
+            - foo: date
+        image: node:4
+        environment:
+            VAR0: 0
+            VAR1: 1
+            VAR2: 2
+            VAR3: 3
+            VAR4: 4
+            VAR5: 5
+            VAR6: 6
+            VAR7: 7
+            VAR8: 8
+            VAR9: 9
+            VAR10: 10
+            VAR11: 11
+            VAR12: 12
+            VAR13: 13
+            VAR14: 14
+            VAR15: 15
+            VAR16: 16
+            VAR17: 17
+            VAR18: 18
+            VAR19: 19
+            VAR20: 20
+            VAR21: 21
+            VAR22: 22
+            VAR23: 23
+            VAR24: 24
+            VAR25: 25
+            VAR26: 26
+            VAR27: 27
+            VAR28: 28
+            VAR29: 29
+            VAR30: 30
+            VAR31: 31
+            VAR32: 32
+            VAR33: 33
+            VAR34: 34
+            SD_TEMPLATE_NAME: mytemplate
+            SD_TEMPLATE_VERSION: 1.2.3

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -270,6 +270,14 @@ describe('config parser', () => {
                 })
         );
 
+        it('do not count SD_TEMPLATE variables for max environment variables', () =>
+            parser(loadData('environment-with-SD-variable.yaml'))
+                .then((data) => {
+                    assert.notMatch(data.jobs.main[0].commands[0].command,
+                        /"environment" can only have 35 environment/);
+                })
+        );
+
         it('returns an error if too many environment + matrix variables', () =>
             parser(loadData('too-many-matrix.yaml'))
                 .then((data) => {


### PR DESCRIPTION
## Context
Users may want to know the exact template version inside their builds for debug purpose

## Objective
This PR will make `SD_TEMPLATE_NAME` and `SD_TEMPLATE_VERSION` available inside users' build if they are using templates.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/960