### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   },
   "engines": {
-    "node": "^6.0.0"
+    "node": "^8.0.0"
   },
   "engine-strict": true,
   "devDependencies": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:

--- a/test/data/node-module.yaml
+++ b/test/data/node-module.yaml
@@ -1,6 +1,3 @@
-workflow:
-    - publish
-
 shared:
     environment:
         NODE_ENV: test


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`
* Update the `engines` property in `package.json`