### PR TITLE
feat(1041): Support job scm

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -99,7 +99,7 @@ function flattenSharedIntoJobs(shared, jobs) {
         const oldJob = clone(jobs[jobName]);
 
         // Replace
-        ['image', 'matrix', 'steps', 'template', 'description'].forEach((key) => {
+        ['image', 'matrix', 'steps', 'template', 'description', 'scm'].forEach((key) => {
             if (oldJob[key]) {
                 newJob[key] = oldJob[key];
             }

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -47,6 +47,10 @@ module.exports = validatedDoc => (
                 job.sourcePaths = doc.jobs[jobName].sourcePaths;
             }
 
+            if (doc.jobs[jobName].scm !== undefined) {
+                job.scm = doc.jobs[jobName].scm;
+            }
+
             const matrix = Hoek.reach(doc, `jobs.${jobName}.matrix`, {
                 default: {}
             });

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "joi": "^13.0.0",
     "js-yaml": "^3.11.0",
     "keymbinatorial": "^1.1.4",
-    "screwdriver-data-schema": "^18.13.0",
+    "screwdriver-data-schema": "^18.17.0",
     "screwdriver-workflow-parser": "^1.4.1",
     "tinytim": "^0.1.1"
   }

--- a/test/data/pipeline-with-scm.json
+++ b/test/data/pipeline-with-scm.json
@@ -1,0 +1,35 @@
+{
+    "annotations": {},
+    "jobs": {
+        "component": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "scm": {
+                    "repo": "git@github.com:screwdriver-cd/data-schema.git/RepoManifest.xml#branch"
+                },
+                "image": "node:6",
+                "requires": ["~commit", "~pr"],
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install"
+                    }
+                ]
+            }
+        ]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "component" }
+        ],
+        "edges": [
+            { "src": "~commit", "dest": "component" },
+            { "src": "~pr", "dest": "component" }
+        ]
+    }
+}

--- a/test/data/pipeline-with-scm.yaml
+++ b/test/data/pipeline-with-scm.yaml
@@ -1,0 +1,13 @@
+shared:
+    image: node:6
+    scm:
+      repo: git@github.com:screwdriver-cd/data-schema.git
+jobs:
+    component:
+        steps:
+            - install: npm install
+        requires:
+            - ~commit
+            - ~pr
+        scm:
+          repo: git@github.com:screwdriver-cd/data-schema.git/RepoManifest.xml#branch

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -193,6 +193,14 @@ describe('config parser', () => {
                 })
         );
 
+        it('job-level scm overrides shared-level scm', () =>
+            parser(loadData('pipeline-with-scm.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data,
+                        JSON.parse(loadData('pipeline-with-scm.json')));
+                })
+        );
+
         describe('templates', () => {
             const templateFactoryMock = {
                 getTemplate: sinon.stub()


### PR DESCRIPTION
Include the `scm` object as part of the parsed config. Similar to other fields, job-level `scm` will overwrite shared-level `scm`.

https://github.com/screwdriver-cd/screwdriver/issues/1041