### PR TITLE
fix(926): Add env vars for template namespace and full name

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -139,10 +139,19 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
             const newJob = template.config;
             const environment = newJob.environment || {};
 
-            // Inject template version and name to env
+            // Construct full template name
+            let fullName = template.name;
+
+            if (template.namespace && template.namespace !== 'default') {
+                fullName = `${template.namespace}/${template.name}`;
+            }
+
+            // Inject template full name, name, namespace, and version to env
             newJob.environment = Hoek.merge(environment, {
-                SD_TEMPLATE_VERSION: template.version,
-                SD_TEMPLATE_NAME: template.name
+                SD_TEMPLATE_FULLNAME: fullName,
+                SD_TEMPLATE_NAME: template.name,
+                SD_TEMPLATE_NAMESPACE: template.namespace || '',
+                SD_TEMPLATE_VERSION: template.version
             });
 
             merge(newJob, oldJob, true);

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -11,8 +11,13 @@ const MAX_ENVIRONMENT_VARS = 35;
 // If they are trying to execute >25 permutations,
 // maybe there is a better way to accomplish their goal.
 const MAX_PERMUTATIONS = 25;
-// Env that created by screwdriver instead of user
-const SDEnv = ['SD_TEMPLATE_NAME', 'SD_TEMPLATE_VERSION'];
+// Env that is created by Screwdriver instead of user
+const SDEnv = [
+    'SD_TEMPLATE_FULLNAME',
+    'SD_TEMPLATE_NAME',
+    'SD_TEMPLATE_NAMESPACE',
+    'SD_TEMPLATE_VERSION'
+];
 
 /**
  * Make sure the Matrix they specified is valid

--- a/test/data/basic-job-with-template-override-steps.json
+++ b/test/data/basic-job-with-template-override-steps.json
@@ -21,7 +21,9 @@
             "environment": {
                 "FOO": "from template",
                 "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
                 "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
                 "SD_TEMPLATE_VERSION": "1.2.3"
             },
             "secrets": [

--- a/test/data/basic-job-with-template-with-namespace.json
+++ b/test/data/basic-job-with-template-with-namespace.json
@@ -10,24 +10,16 @@
                     "command": "npm install"
                 },
                 {
-                    "name": "postinstall",
-                    "command": "echo post-install"
-                },
-                {
-                    "name": "pretest",
-                    "command": "echo pre-test"
-                },
-                {
                     "name": "test",
                     "command": "npm test"
                 }
             ],
             "environment": {
-                "FOO": "from template",
+                "FOO": "overwritten by job",
                 "BAR": "foo",
-                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_FULLNAME": "mynamespace/mytemplate",
                 "SD_TEMPLATE_NAME": "mytemplate",
-                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_NAMESPACE": "mynamespace",
                 "SD_TEMPLATE_VERSION": "1.2.3"
             },
             "secrets": [
@@ -40,17 +32,40 @@
                 "~pr",
                 "~commit"
             ]
-        }]
+        }],
+      "publish": [{
+          "annotations": {},
+          "image": "node:4",
+          "commands": [
+              {
+                  "name": "publish",
+                  "command": "npm publish"
+              }
+          ],
+          "environment": {
+              "SD_TEMPLATE_FULLNAME": "yourtemplate",
+              "SD_TEMPLATE_NAME": "yourtemplate",
+              "SD_TEMPLATE_NAMESPACE": "default",
+              "SD_TEMPLATE_VERSION": "2"
+          },
+          "secrets": [],
+          "settings": {},
+          "requires": [
+              "main"
+          ]
+      }]
     },
     "workflowGraph": {
         "nodes": [
             { "name": "~pr" },
             { "name": "~commit" },
-            { "name": "main" }
+            { "name": "main" },
+            { "name": "publish" }
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
-            { "src": "~commit", "dest": "main" }
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" }
         ]
     }
 }

--- a/test/data/basic-job-with-template-with-namespace.yaml
+++ b/test/data/basic-job-with-template-with-namespace.yaml
@@ -1,0 +1,12 @@
+jobs:
+    main:
+        template: mynamespace/mytemplate@1.2.3
+        environment:
+            FOO: 'overwritten by job'
+        requires:
+            - ~pr
+            - ~commit
+    publish:
+        template: yourtemplate@2
+        requires:
+            - main

--- a/test/data/basic-job-with-template.json
+++ b/test/data/basic-job-with-template.json
@@ -17,7 +17,9 @@
             "environment": {
                 "FOO": "overwritten by job",
                 "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
                 "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
                 "SD_TEMPLATE_VERSION": "1.2.3"
             },
             "secrets": [
@@ -41,7 +43,9 @@
               }
           ],
           "environment": {
+              "SD_TEMPLATE_FULLNAME": "yourtemplate",
               "SD_TEMPLATE_NAME": "yourtemplate",
+              "SD_TEMPLATE_NAMESPACE": "",
               "SD_TEMPLATE_VERSION": "2"
           },
           "secrets": [],

--- a/test/data/pipeline-with-blocked-by.json
+++ b/test/data/pipeline-with-blocked-by.json
@@ -24,7 +24,7 @@
                 "settings": {},
                 "environment": {},
                 "requires": ["~commit"],
-                "blockedBy": ["main", "~sd@123:publish"],
+                "blockedBy": ["~main", "~sd@123:publish"],
                 "image": "node:4",
                 "commands": [
                     {

--- a/test/data/pipeline-with-blocked-by.yaml
+++ b/test/data/pipeline-with-blocked-by.yaml
@@ -10,5 +10,5 @@ jobs:
             - echo-hello: echo hello
         requires: ~commit
         blockedBy:
-            - main
+            - ~main
             - ~sd@123:publish

--- a/test/data/templateWithDefaultNamespace.json
+++ b/test/data/templateWithDefaultNamespace.json
@@ -1,0 +1,14 @@
+{
+    "name": "yourtemplate",
+    "namespace": "default",
+    "version": "2",
+    "description": "test template",
+    "maintainer": "foo@bar.com",
+    "labels": [],
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "publish": "npm publish" }
+        ]
+    }
+}

--- a/test/data/templateWithNamespace.json
+++ b/test/data/templateWithNamespace.json
@@ -1,0 +1,25 @@
+{
+    "name": "mytemplate",
+    "namespace": "mynamespace",
+    "version": "1.2.3",
+    "description": "test template",
+    "maintainer": "bar@foo.com",
+    "labels": [],
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "install": "npm install" },
+            { "test": "npm test" }
+        ],
+        "environment": {
+            "FOO": "from template",
+            "BAR": "foo"
+        },
+        "secrets": [
+            "GIT_KEY"
+        ],
+        "settings": {
+            "email": "foo@example.com"
+        }
+    }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -207,21 +207,37 @@ describe('config parser', () => {
             };
             let firstTemplate;
             let secondTemplate;
+            let namespaceTemplate;
+            let defaultTemplate;
 
             beforeEach(() => {
                 firstTemplate = JSON.parse(loadData('template.json'));
                 secondTemplate = JSON.parse(loadData('template-2.json'));
+                namespaceTemplate = JSON.parse(loadData('templateWithNamespace.json'));
+                defaultTemplate = JSON.parse(loadData('templateWithDefaultNamespace.json'));
                 templateFactoryMock.getTemplate.withArgs('mytemplate@1.2.3')
                     .resolves(firstTemplate);
                 templateFactoryMock.getTemplate.withArgs('yourtemplate@2')
                     .resolves(secondTemplate);
+                templateFactoryMock.getTemplate.withArgs('mynamespace/mytemplate@1.2.3')
+                    .resolves(namespaceTemplate);
             });
 
-            it('flattens templates sucessfully', () =>
+            it('flattens templates successfully', () =>
                 parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
                     .then(data => assert.deepEqual(
                         data, JSON.parse(loadData('basic-job-with-template.json'))))
             );
+
+            it('flattens templates successfully when template namespace exists', () => {
+                templateFactoryMock.getTemplate.withArgs('yourtemplate@2')
+                    .resolves(defaultTemplate);
+
+                return parser(loadData('basic-job-with-template-with-namespace.yaml'),
+                    templateFactoryMock)
+                    .then(data => assert.deepEqual(
+                        data, JSON.parse(loadData('basic-job-with-template-with-namespace.json'))));
+            });
 
             it('flattens templates with wrapped steps ', () =>
                 parser(loadData('basic-job-with-template-wrapped-steps.yaml'), templateFactoryMock)


### PR DESCRIPTION
## Context
It will be confusing for users now that the `namespace` field can be implicitly created if they enter `tiff/template@1.0.2` into the validator and get `SD_TEMPLATE_NAME: template` as a result.

## Objective
This PR adds `SD_TEMPLATE_NAMESPACE` and `SD_TEMPLATE_FULLNAME` to the env vars so users can use `SD_TEMPLATE_FULLNAME` directly to invoke a template.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/926