### PR TITLE
fix: error config should not have scmUrls field

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ module.exports = function configParser(yaml, templateFactory) {
                     environment: {}
                 }]
             },
-            scmUrls: [],
             workflowGraph: {
                 nodes: [
                     { name: '~pr' },


### PR DESCRIPTION
This will cause validation err since scmUrls need to have at lease one item