### PR TITLE
feat(1040): resolve job image alias with template images

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -154,15 +154,15 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
                 SD_TEMPLATE_VERSION: template.version
             });
 
+            merge(newJob, oldJob, true);
+            delete newJob.template;
+
             // If template.images contains a label match for the image defined in the job
             // set the job image to the respective template image
             if (typeof template.images !== 'undefined' &&
                 typeof template.images[newJob.image] !== 'undefined') {
                 newJob.image = template.images[newJob.image];
             }
-
-            merge(newJob, oldJob, true);
-            delete newJob.template;
 
             newJobs[jobName] = newJob;
 

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -154,8 +154,16 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
                 SD_TEMPLATE_VERSION: template.version
             });
 
+            // If template.images contains a label match for the image defined in the job
+            // set the job image to the respective template image
+            if (typeof template.images !== 'undefined' &&
+                typeof template.images[newJob.image] !== 'undefined') {
+                newJob.image = template.images[newJob.image];
+            }
+
             merge(newJob, oldJob, true);
             delete newJob.template;
+
             newJobs[jobName] = newJob;
 
             return null;

--- a/test/data/basic-job-with-images.json
+++ b/test/data/basic-job-with-images.json
@@ -1,0 +1,62 @@
+{
+  "annotations": {},
+  "jobs": {
+    "main": [
+      {
+        "annotations": {},
+        "commands": [
+          {
+            "command": "npm install",
+            "name": "install"
+          },
+          {
+            "command": "echo hello world",
+            "name": "hello"
+          }
+        ],
+        "environment": {
+          "SD_TEMPLATE_FULLNAME": "imagestemplate",
+          "SD_TEMPLATE_NAME": "imagestemplate",
+          "SD_TEMPLATE_NAMESPACE": "",
+          "SD_TEMPLATE_VERSION": "2"
+        },
+        "image": "node:5",
+        "secrets": [],
+        "settings": {}
+      }
+    ],
+    "publish": [
+      {
+        "annotations": {},
+        "commands": [
+          {
+            "command": "npm publish",
+            "name": "publish"
+          }
+        ],
+        "description": "This is the publish description",
+        "environment": {},
+        "image": "node:4",
+        "secrets": [],
+        "settings": {}
+      }
+    ]
+  },
+  "workflowGraph": {
+    "edges": [],
+    "nodes": [
+      {
+        "name": "~pr"
+      },
+      {
+        "name": "~commit"
+      },
+      {
+        "name": "publish"
+      },
+      {
+        "name": "main"
+      }
+    ]
+  }
+}

--- a/test/data/basic-job-with-images.json
+++ b/test/data/basic-job-with-images.json
@@ -15,9 +15,9 @@
           }
         ],
         "environment": {
-          "SD_TEMPLATE_FULLNAME": "imagestemplate",
+          "SD_TEMPLATE_FULLNAME": "ImagesTestNamespace/imagestemplate",
           "SD_TEMPLATE_NAME": "imagestemplate",
-          "SD_TEMPLATE_NAMESPACE": "",
+          "SD_TEMPLATE_NAMESPACE": "ImagesTestNamespace",
           "SD_TEMPLATE_VERSION": "2"
         },
         "image": "node:5",

--- a/test/data/basic-job-with-images.yaml
+++ b/test/data/basic-job-with-images.yaml
@@ -1,7 +1,7 @@
 jobs:
     main:
         image: latest-image
-        template: imagestemplate@2
+        template: ImagesTestNamespace/imagestemplate@2
         description: "This is the main description"
     publish:
         image: node:4

--- a/test/data/basic-job-with-images.yaml
+++ b/test/data/basic-job-with-images.yaml
@@ -1,0 +1,10 @@
+jobs:
+    main:
+        image: latest-image
+        template: imagestemplate@2
+        description: "This is the main description"
+    publish:
+        image: node:4
+        description: "This is the publish description"
+        steps:
+            - publish: "npm publish"

--- a/test/data/templateWithImages.json
+++ b/test/data/templateWithImages.json
@@ -1,4 +1,5 @@
 {
+    "namespace": "ImagesTestNamespace",
     "name": "imagestemplate",
     "version": "2",
     "description": "test template",

--- a/test/data/templateWithImages.json
+++ b/test/data/templateWithImages.json
@@ -1,0 +1,18 @@
+{
+    "name": "imagestemplate",
+    "version": "2",
+    "description": "test template",
+    "maintainer": "foo@bar.com",
+    "labels": [],
+    "images": {
+        "stable-image": "node:4",
+        "latest-image": "node:5"
+    },
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "install": "npm install" },
+            { "hello": "echo hello world" }
+        ]
+    }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -227,18 +227,22 @@ describe('config parser', () => {
             let secondTemplate;
             let namespaceTemplate;
             let defaultTemplate;
+            let imagesTemplate;
 
             beforeEach(() => {
                 firstTemplate = JSON.parse(loadData('template.json'));
                 secondTemplate = JSON.parse(loadData('template-2.json'));
                 namespaceTemplate = JSON.parse(loadData('templateWithNamespace.json'));
                 defaultTemplate = JSON.parse(loadData('templateWithDefaultNamespace.json'));
+                imagesTemplate = JSON.parse(loadData('templateWithImages.json'));
                 templateFactoryMock.getTemplate.withArgs('mytemplate@1.2.3')
                     .resolves(firstTemplate);
                 templateFactoryMock.getTemplate.withArgs('yourtemplate@2')
                     .resolves(secondTemplate);
                 templateFactoryMock.getTemplate.withArgs('mynamespace/mytemplate@1.2.3')
                     .resolves(namespaceTemplate);
+                templateFactoryMock.getTemplate.withArgs('imagestemplate@2')
+                    .resolves(imagesTemplate);
             });
 
             it('flattens templates successfully', () =>
@@ -267,6 +271,12 @@ describe('config parser', () => {
                 parser(loadData('basic-job-with-template-override-steps.yaml'), templateFactoryMock)
                     .then(data => assert.deepEqual(
                         data, JSON.parse(loadData('basic-job-with-template-override-steps.json'))))
+            );
+
+            it('flattens templates with images', () =>
+                parser(loadData('basic-job-with-images.yaml'), templateFactoryMock)
+                    .then(data => assert.deepEqual(
+                        data, JSON.parse(loadData('basic-job-with-images.json'))))
             );
 
             it('returns error if template does not exist', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -241,7 +241,7 @@ describe('config parser', () => {
                     .resolves(secondTemplate);
                 templateFactoryMock.getTemplate.withArgs('mynamespace/mytemplate@1.2.3')
                     .resolves(namespaceTemplate);
-                templateFactoryMock.getTemplate.withArgs('imagestemplate@2')
+                templateFactoryMock.getTemplate.withArgs('ImagesTestNamespace/imagestemplate@2')
                     .resolves(imagesTemplate);
             });
 


### PR DESCRIPTION
## Context

If a user job references an image alias from a template images directive, this should be flattened such that the job uses the resolved image path.

## References

* Issue: https://github.com/screwdriver-cd/screwdriver/issues/1040