### PR TITLE
fix(937): Add childPipelines object

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,12 +64,12 @@ module.exports = function configParser(yaml, templateFactory) {
             const res = {
                 annotations: Hoek.reach(doc, 'annotations', { default: {} }),
                 jobs: Hoek.reach(doc, 'jobs'),
-                scmUrls: Hoek.reach(doc, 'scmUrls', { default: [] }),
+                childPipelines: Hoek.reach(doc, 'childPipelines', { default: {} }),
                 workflowGraph: Hoek.reach(doc, 'workflowGraph')
             };
 
-            if (res.scmUrls.length === 0) {
-                delete res.scmUrls;
+            if (Hoek.deepEqual(res.childPipelines, {})) {
+                delete res.childPipelines;
             }
 
             return res;

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
   "dependencies": {
     "clone": "^2.1.2",
     "hoek": "^5.0.3",
-    "joi": "^13.3.0",
-    "js-yaml": "^3.11.0",
+    "joi": "^13.4.0",
+    "js-yaml": "^3.12.0",
     "keymbinatorial": "^1.1.4",
-    "screwdriver-data-schema": "^18.21.4",
+    "screwdriver-data-schema": "^18.24.3",
     "screwdriver-workflow-parser": "^1.4.2",
     "tinytim": "^0.1.1"
   }

--- a/test/data/bad-external-scm.yaml
+++ b/test/data/bad-external-scm.yaml
@@ -1,0 +1,3 @@
+childPipelines:
+    scmUrls:
+     - fakeScmUrl

--- a/test/data/bad-scm-url.yaml
+++ b/test/data/bad-scm-url.yaml
@@ -1,2 +1,0 @@
-scmUrls:
- - fakeScmUrl

--- a/test/data/pipeline-with-childPipelines.json
+++ b/test/data/pipeline-with-childPipelines.json
@@ -57,10 +57,13 @@
             }
         ]
     },
-    "scmUrls": [
-        "git@github.com:org/repo.git",
-        "https://github.com:org/repo2.git"
-    ],
+    "childPipelines": {
+        "scmUrls": [
+            "git@github.com:org/repo.git",
+            "https://github.com:org/repo2.git"
+        ],
+        "startAll": true
+    },
     "workflowGraph": {
         "nodes": [
             { "name": "~pr" },

--- a/test/data/pipeline-with-childPipelines.yaml
+++ b/test/data/pipeline-with-childPipelines.yaml
@@ -1,6 +1,8 @@
-scmUrls:
-    - git@github.com:org/repo.git
-    - https://github.com:org/repo2.git
+childPipelines:
+    scmUrls:
+        - git@github.com:org/repo.git
+        - https://github.com:org/repo2.git
+    startAll: true
 
 shared:
     image: node:4

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,9 +138,9 @@ describe('config parser', () => {
             );
         });
 
-        describe('scmUrls', () => {
-            it('returns an error if bad scm URL', () =>
-                parser(loadData('bad-scm-url.yaml'))
+        describe('childPipelines', () => {
+            it('returns an error if bad childPipelines', () =>
+                parser(loadData('bad-external-scm.yaml'))
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
                             /"fakeScmUrl" fails to match the required pattern:/);
@@ -212,10 +212,10 @@ describe('config parser', () => {
         );
 
         it('includes scm URLs', () =>
-            parser(loadData('pipeline-with-scmUrls.yaml'))
+            parser(loadData('pipeline-with-childPipelines.yaml'))
                 .then((data) => {
                     assert.deepEqual(data,
-                        JSON.parse(loadData('pipeline-with-scmUrls.json')));
+                        JSON.parse(loadData('pipeline-with-childPipelines.json')));
                 })
         );
 


### PR DESCRIPTION
## Context
Since are now encompassing `scmUrls` into a parent object, `childPipelines`, we need to parse this value instead.

## Objective
Parse `childPipelines` instead of `scmUrls`.

## Reference
**Pending**:
 - https://github.com/screwdriver-cd/data-schema/pull/251

https://github.com/screwdriver-cd/screwdriver/issues/937