### PR TITLE
fix: do not check duplicate if no step name

### DIFF
--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -24,9 +24,10 @@ function checkAdditionalRules(data) {
             for (let i = 0; i < steps.length; i += 1) {
                 const stepName = Object.keys(steps[i])[0];
 
-                if (stepList.includes(stepName)) {
+                if ((typeof (steps[i]) === 'object') && (stepList.includes(stepName))) {
                     error.push(new Error(`Job ${job} has duplicate step: ${stepName}`));
                 }
+
                 stepList.push(stepName);
                 const isUserTeardown = Object.keys(steps[i])[0].startsWith('teardown-');
 

--- a/test/data/basic-job-with-no-step-names.yaml
+++ b/test/data/basic-job-with-no-step-names.yaml
@@ -1,0 +1,8 @@
+jobs:
+  main:
+        image: node:6
+        description: "This is the publish description"
+        steps:
+            - npm publish
+            - echo duplciate step
+            - teardown-mystep: "echo bye"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,6 +70,16 @@ describe('config parser', () => {
                 })
         );
 
+        it('does not return an error if job has no step names', () =>
+            parser(loadData('basic-job-with-no-step-names.yaml'))
+                .then((data) => {
+                    assert.strictEqual(data.jobs.main[0].image, 'node:6');
+                    assert.deepEqual(data.jobs.main[0].secrets, []);
+                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.notOk(data.errors);
+                })
+        );
+
         it('returns an error if multiple documents without hint', () =>
             parser('foo: bar\n---\nfoo: baz')
                 .then((data) => {


### PR DESCRIPTION
We also support steps that don't have names. In those cases, it should skip duplicate step check. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1253