### PR TITLE
feat(1280): support cache config

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -11,12 +11,14 @@ const clone = require('clone');
  * @return {Object}                         new jobs with cache config flattened
  */
 function flattenCacheSettings(cacheConfig, jobs) {
-    const cache = Hoek.reach(cacheConfig, 'pipeline', { default: [] })
-        .concat(Hoek.reach(cacheConfig, 'event', { default: [] }));
+    const cache = {
+        pipeline: Hoek.reach(cacheConfig, 'pipeline', { default: [] }),
+        event: Hoek.reach(cacheConfig, 'event', { default: [] })
+    };
 
     Object.keys(jobs).forEach((jobName) => {
-        jobs[jobName].cache = cache.concat(
-            Hoek.reach(cacheConfig, `job.${jobName}`, { default: [] }));
+        jobs[jobName].cache = Hoek.applyToDefaults(cache,
+            { job: Hoek.reach(cacheConfig, `job.${jobName}`, { default: [] }) });
     });
 
     return jobs;

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -4,6 +4,25 @@ const Hoek = require('hoek');
 const clone = require('clone');
 
 /**
+ * Flatten cache settings to each job
+ * @method flattenCacheSettings
+ * @param  {Object}             cacheConfig top-level cache settings
+ * @param  {Object}             jobs       jobs from screwdriver yaml
+ * @return {Object}                         new jobs with cache config flattened
+ */
+function flattenCacheSettings(cacheConfig, jobs) {
+    const cache = Hoek.reach(cacheConfig, 'pipeline', { default: [] })
+        .concat(Hoek.reach(cacheConfig, 'event', { default: [] }));
+
+    Object.keys(jobs).forEach((jobName) => {
+        jobs[jobName].cache = cache.concat(
+            Hoek.reach(cacheConfig, `job.${jobName}`, { default: [] }));
+    });
+
+    return jobs;
+}
+
+/**
  * Merge oldJob into newJob
  * "oldJob" takes precedence over "newJob". For ex: individual job settings vs shared settings
  * @param  {Object}   newJob        Job to be merged into. For ex: shared settings
@@ -294,6 +313,11 @@ module.exports = (parsedDoc, templateFactory) => {
     // Flatten shared into jobs
     doc.jobs = flattenSharedIntoJobs(parsedDoc.shared, parsedDoc.jobs);
     delete doc.shared;
+
+    if (parsedDoc.cache) {
+        doc.jobs = flattenCacheSettings(parsedDoc.cache, doc.jobs);
+        delete doc.cache;
+    }
 
     // Flatten templates
     return flattenTemplates(doc.jobs, templateFactory)

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -33,6 +33,10 @@ module.exports = validatedDoc => (
                 })
             };
 
+            if (doc.jobs[jobName].cache !== undefined) {
+                job.cache = doc.jobs[jobName].cache;
+            }
+
             if (doc.jobs[jobName].description !== undefined) {
                 job.description = doc.jobs[jobName].description;
             }

--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -40,6 +40,14 @@ function checkAdditionalRules(data) {
                 }
             }
         }
+
+        if (data.cache && data.cache.job) { // make sure the job under job scope exists
+            Object.keys(data.cache.job).forEach((jobname) => {
+                if (!(jobname in data.jobs)) {
+                    error.push(new Error(`Cache is set for non-existing job: ${jobname}`));
+                }
+            });
+        }
     });
 
     return error.length === 0 ? null : error;

--- a/test/data/pipeline-cache-nonexist-job.json
+++ b/test/data/pipeline-cache-nonexist-job.json
@@ -1,0 +1,44 @@
+{
+    "annotations": {},
+    "jobs": {
+        "main": [
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "config-parse-error",
+                        "command": "echo \"Error: Cache is set for non-existing job: badjob\"; exit 1"
+                    }
+                ],
+                "secrets": [],
+                "environment": {}
+            }
+        ]
+    },
+    "workflowGraph": {
+        "nodes": [
+            {
+                "name": "~pr"
+            },
+            {
+                "name": "~commit"
+            },
+            {
+                "name": "main"
+            }
+        ],
+        "edges": [
+            {
+                "src": "~pr",
+                "dest": "main"
+            },
+            {
+                "src": "~commit",
+                "dest": "main"
+            }
+        ]
+    },
+    "errors": [
+        "Error: Cache is set for non-existing job: badjob"
+    ]
+}

--- a/test/data/pipeline-cache-nonexist-job.yaml
+++ b/test/data/pipeline-cache-nonexist-job.yaml
@@ -1,0 +1,11 @@
+cache:
+  job:
+      badjob: ['~/test']
+jobs:
+    main:
+        image: node:4
+        steps:
+            - install: npm install
+        requires:
+            - ~pr
+            - ~commit

--- a/test/data/pipeline-cache.json
+++ b/test/data/pipeline-cache.json
@@ -19,13 +19,19 @@
                     "~pr",
                     "~commit"
                 ],
-                "cache": [
-                    "/tmp/test",
-                    "/sd/workspace/test/",
-                    "/tmp/test",
-                    "a.b",
-                    "mainjob"
-                ]
+                "cache": {
+                    "event": [
+                        "/sd/workspace/test/",
+                        "/tmp/test",
+                        "a.b"
+                    ],
+                    "pipeline": [
+                        "/tmp/test"
+                    ],
+                    "job": [
+                        "mainjob"
+                    ]
+                }
             }
         ],
         "test": [
@@ -45,12 +51,17 @@
                 "requires": [
                     "main"
                 ],
-                "cache": [
-                    "/tmp/test",
-                    "/sd/workspace/test/",
-                    "/tmp/test",
-                    "a.b"
-                ]
+                "cache": {
+                    "event": [
+                        "/sd/workspace/test/",
+                        "/tmp/test",
+                        "a.b"
+                    ],
+                    "pipeline": [
+                        "/tmp/test"
+                    ],
+                    "job": []
+                }
             }
         ],
         "publish": [
@@ -70,13 +81,19 @@
                 "requires": [
                     "test"
                 ],
-                "cache": [
-                    "/tmp/test",
-                    "/sd/workspace/test/",
-                    "/tmp/test",
-                    "a.b",
-                    "publishjob"
-                ]
+                "cache": {
+                    "event": [
+                        "/sd/workspace/test/",
+                        "/tmp/test",
+                        "a.b"
+                    ],
+                    "pipeline": [
+                        "/tmp/test"
+                    ],
+                    "job": [
+                        "publishjob"
+                    ]
+                }
             }
         ]
     },

--- a/test/data/pipeline-cache.json
+++ b/test/data/pipeline-cache.json
@@ -1,0 +1,98 @@
+{
+    "annotations": {},
+    "jobs": {
+        "main": [
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install"
+                    }
+                ],
+                "environment": {
+                },
+                "secrets": [],
+                "settings": {},
+                "requires": [
+                    "~pr",
+                    "~commit"
+                ],
+                "cache": [
+                    "/tmp/test",
+                    "/sd/workspace/test/",
+                    "/tmp/test",
+                    "a.b",
+                    "mainjob"
+                ]
+            }
+        ],
+        "test": [
+            {
+                "annotations": {},
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                },
+                "secrets": [],
+                "settings": {},
+                "requires": [
+                    "main"
+                ],
+                "cache": [
+                    "/tmp/test",
+                    "/sd/workspace/test/",
+                    "/tmp/test",
+                    "a.b"
+                ]
+            }
+        ],
+        "publish": [
+            {
+                "annotations": {},
+                "image": "node:10",
+                "commands": [
+                    {
+                        "name": "publish",
+                        "command": "npm publish"
+                    }
+                ],
+                "environment": {
+                },
+                "secrets": [],
+                "settings": {},
+                "requires": [
+                    "test"
+                ],
+                "cache": [
+                    "/tmp/test",
+                    "/sd/workspace/test/",
+                    "/tmp/test",
+                    "a.b",
+                    "publishjob"
+                ]
+            }
+        ]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "test" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "test" },
+            { "src": "test", "dest": "publish" }
+        ]
+    }
+}

--- a/test/data/pipeline-cache.yaml
+++ b/test/data/pipeline-cache.yaml
@@ -1,0 +1,26 @@
+cache:
+  pipeline: ['/tmp/test']
+  event: ['/sd/workspace/test/', '/tmp/test', 'a.b']
+  job:
+      main: ['mainjob']
+      publish: ['publishjob']
+jobs:
+    main:
+        image: node:4
+        steps:
+            - install: npm install
+        requires:
+            - ~pr
+            - ~commit
+    test:   # no job cache
+        image: node:6
+        steps:
+            - test: npm test
+        requires:
+            - main
+    publish:
+        image: node:10
+        steps:
+            - publish: npm publish
+        requires:
+            - test

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -384,6 +384,21 @@ describe('config parser', () => {
                 })
         );
 
+        it('reads cache on the pipeline-level', () =>
+            parser(loadData('pipeline-cache.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data, JSON.parse(loadData('pipeline-cache.json')));
+                })
+        );
+
+        it('returns an error if job specified in cache config does not exist', () =>
+            parser(loadData('pipeline-cache-nonexist-job.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data, JSON.parse(
+                        loadData('pipeline-cache-nonexist-job.json')));
+                })
+        );
+
         it('allows a description key', () =>
             parser(loadData('basic-job-with-description.yaml'))
                 .then((data) => {


### PR DESCRIPTION
Flatten cache settings to each job. 
If there is a setting for a non-existing job, will return error. 

Blocked by:
https://github.com/screwdriver-cd/data-schema/pull/287

Related: 
https://github.com/screwdriver-cd/screwdriver/issues/1257
https://github.com/screwdriver-cd/screwdriver/issues/1280