### PR TITLE
fix: merge cache for template

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -51,6 +51,10 @@ function merge(newJob, oldJob, fromTemplate) {
         newJob.blockedBy = [].concat(oldJob.blockedBy);
     }
 
+    if (oldJob.cache) {
+        newJob.cache = oldJob.cache;
+    }
+
     // Merge secrets
     const newSecrets = newJob.secrets || [];
     const oldSecrets = oldJob.secrets || [];

--- a/test/data/basic-job-with-template-override-steps.json
+++ b/test/data/basic-job-with-template-override-steps.json
@@ -18,6 +18,11 @@
                     "command": "echo 'my job is overriding this step'"
                 }
             ],
+            "cache": {
+              "event": ["/tmp/test"],
+              "job": [],
+              "pipeline": []
+            },
             "environment": {
                 "FOO": "from template",
                 "BAR": "foo",

--- a/test/data/basic-job-with-template-override-steps.yaml
+++ b/test/data/basic-job-with-template-override-steps.yaml
@@ -1,3 +1,5 @@
+cache:
+    event: [/tmp/test]
 jobs:
     main:
         template: mytemplate@1.2.3


### PR DESCRIPTION
Currently if the job is using template, then the cache setting is not merged into the job permutations. Therefore, cache bookend is skipped. 
This PR addresses the issue. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1284, https://github.com/screwdriver-cd/screwdriver/issues/1257