### PR TITLE
feat(1319): Throw error if build cluster annotation is not a valid option

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,11 +44,12 @@ function parseYaml(yaml) {
 /**
  * Parse the configuration from a screwdriver.yaml
  * @method configParser
- * @param  {String}           yaml              Contents of screwdriver.yaml
- * @param  {TemplateFactory}  templateFactory   Template Factory to get templates
+ * @param  {String}               yaml                Contents of screwdriver.yaml
+ * @param  {BuildClusterFactory}  buildClusterFactory Build cluster Factory to get build clusters
+ * @param  {TemplateFactory}      templateFactory     Template Factory to get templates
  * @returns {Promise}
  */
-module.exports = function configParser(yaml, templateFactory) {
+module.exports = function configParser(yaml, templateFactory, buildClusterFactory) {
     // Convert from YAML to JSON
     return parseYaml(yaml)
         // Basic validation
@@ -56,7 +57,7 @@ module.exports = function configParser(yaml, templateFactory) {
         // Flatten structures
         .then(parsedDoc => phaseFlatten(parsedDoc, templateFactory))
         // Functionality validation
-        .then(phaseValidateFunctionality)
+        .then(flattenedDoc => phaseValidateFunctionality(flattenedDoc, buildClusterFactory))
         // Generate Permutations
         .then(phaseGeneratePermutations)
         // Output in the right format

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -20,6 +20,36 @@ const SDEnv = [
 ];
 
 /**
+ * Ensure the build cluster annotation is valid
+ * @method validateBuildClusterAnnotation
+ * @param  {BuildClusterFactory}  buildClusterFactory Build cluster Factory to get build clusters
+ * @param  {Object}               doc Document that went through flattening
+ * @return {Array}                List of errors
+ */
+function validateBuildClusterAnnotation(doc, buildClusterFactory) {
+    const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+    const buildClusterName = Hoek.reach(doc, 'annotations') ?
+        doc.annotations[buildClusterAnnotation] : undefined;
+
+    if (buildClusterName && buildClusterFactory) {
+        return buildClusterFactory.list()
+            .then(buildClusters => buildClusters.some(buildCluster =>
+                buildCluster.name === buildClusterName
+            ))
+            .then((hasValidBuildCluster) => {
+                if (!hasValidBuildCluster) {
+                    return [`Annotation "${buildClusterAnnotation}": ` +
+                        `${buildClusterName} is not a valid build cluster`];
+                }
+
+                return [];
+            });
+    }
+
+    return Promise.resolve([]);
+}
+
+/**
  * Make sure the Matrix they specified is valid
  * @method validateJobMatrix
  * @param  {Object}      job     Job to inspect
@@ -180,7 +210,7 @@ function validateWorkflowGraph(doc) {
  * @param  {Function} callback     Function to call when done (err, doc)
  * @param  {Promise}
  */
-module.exports = flattenedDoc => (
+module.exports = (flattenedDoc, buildClusterFactory) => (
     new Promise((resolve, reject) => {
         const doc = flattenedDoc;
         let errors = [];
@@ -188,13 +218,20 @@ module.exports = flattenedDoc => (
         // Jobs
         errors = errors.concat(validateJobSchema(doc));
 
+        // Workflow graph
         doc.workflowGraph = generateWorkflowGraph(doc);
         errors = errors.concat(validateWorkflowGraph(doc));
 
-        if (errors.length > 0) {
-            return reject(new Error(errors.join('\n')));
-        }
+        // Check if build cluster annotation is valid
+        return validateBuildClusterAnnotation(doc, buildClusterFactory)
+            .then((errs) => {
+                errors = errors.concat(errs);
 
-        return resolve(doc);
+                if (errors.length > 0) {
+                    return reject(new Error(errors.join('\n')));
+                }
+
+                return resolve(doc);
+            });
     })
 );

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -28,8 +28,8 @@ const SDEnv = [
  */
 function validateBuildClusterAnnotation(doc, buildClusterFactory) {
     const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
-    const buildClusterName = Hoek.reach(doc, 'annotations') ?
-        doc.annotations[buildClusterAnnotation] : undefined;
+    const buildClusterName = Hoek.reach(doc,
+        `annotations>${buildClusterAnnotation}`, { separator: '>' });
 
     if (buildClusterName && buildClusterFactory) {
         return buildClusterFactory.list()

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^4.0.0",
+    "jenkins-mocha": "^6.0.0",
     "sinon": "^2.4.1"
   },
   "dependencies": {

--- a/test/data/bad-build-cluster.json
+++ b/test/data/bad-build-cluster.json
@@ -1,0 +1,44 @@
+{
+    "annotations": {},
+    "jobs": {
+        "main": [
+            {
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "config-parse-error",
+                        "command": "echo \"Error: Annotation \"screwdriver.cd/buildCluster\": doesnotexist is not a valid build cluster\"; exit 1"
+                    }
+                ],
+                "secrets": [],
+                "environment": {}
+            }
+        ]
+    },
+    "workflowGraph": {
+        "nodes": [
+            {
+                "name": "~pr"
+            },
+            {
+                "name": "~commit"
+            },
+            {
+                "name": "main"
+            }
+        ],
+        "edges": [
+            {
+                "src": "~pr",
+                "dest": "main"
+            },
+            {
+                "src": "~commit",
+                "dest": "main"
+            }
+        ]
+    },
+    "errors": [
+        "Error: Annotation \"screwdriver.cd/buildCluster\": doesnotexist is not a valid build cluster"
+    ]
+}

--- a/test/data/bad-build-cluster.yaml
+++ b/test/data/bad-build-cluster.yaml
@@ -1,0 +1,23 @@
+annotations:
+    screwdriver.cd/buildCluster: doesnotexist
+
+jobs:
+    main:
+        image: node:4
+        steps:
+            - install: npm install
+        requires:
+            - ~pr
+            - ~commit
+    test:   # no job cache
+        image: node:6
+        steps:
+            - test: npm test
+        requires:
+            - main
+    publish:
+        image: node:10
+        steps:
+            - publish: npm publish
+        requires:
+            - test

--- a/test/data/build-cluster.json
+++ b/test/data/build-cluster.json
@@ -1,0 +1,80 @@
+{
+    "annotations": {
+        "screwdriver.cd/buildCluster": "test"
+    },
+    "jobs": {
+        "main": [
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install"
+                    }
+                ],
+                "environment": {
+                },
+                "secrets": [],
+                "settings": {},
+                "requires": [
+                    "~pr",
+                    "~commit"
+                ]
+            }
+        ],
+        "test": [
+            {
+                "annotations": {},
+                "image": "node:6",
+                "commands": [
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ],
+                "environment": {
+                },
+                "secrets": [],
+                "settings": {},
+                "requires": [
+                    "main"
+                ]
+            }
+        ],
+        "publish": [
+            {
+                "annotations": {},
+                "image": "node:10",
+                "commands": [
+                    {
+                        "name": "publish",
+                        "command": "npm publish"
+                    }
+                ],
+                "environment": {
+                },
+                "secrets": [],
+                "settings": {},
+                "requires": [
+                    "test"
+                ]
+            }
+        ]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "test" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "test" },
+            { "src": "test", "dest": "publish" }
+        ]
+    }
+}

--- a/test/data/build-cluster.yaml
+++ b/test/data/build-cluster.yaml
@@ -1,0 +1,23 @@
+annotations:
+    screwdriver.cd/buildCluster: test
+
+jobs:
+    main:
+        image: node:4
+        steps:
+            - install: npm install
+        requires:
+            - ~pr
+            - ~commit
+    test:   # no job cache
+        image: node:6
+        steps:
+            - test: npm test
+        requires:
+            - main
+    publish:
+        image: node:10
+        steps:
+            - publish: npm publish
+        requires:
+            - test

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,8 +65,8 @@ describe('config parser', () => {
                     assert.deepEqual(data.jobs.main[0].environment, {});
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
                     assert.match(data.jobs.main[0].commands[0].command,
-                        /Error:.*main has duplicate step: publish/);
-                    assert.match(data.errors[0], /Error:.*main has duplicate step: publish/);
+                        /"steps" position 1 contains a duplicate value/);
+                    assert.match(data.errors[0], /"steps" position 1 contains a duplicate value/);
                 })
         );
 


### PR DESCRIPTION
## Context
In order to support multiple build clusters, we need to update the validator.

## Objective
This PR adds logic to check if the build cluster specified in the `screwdriver.cd/buildCluster` annotation is actually a valid buildCluster in the database.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1319