### PR TITLE
fix: upgrade devDependencies and image of config-parse-error to node:10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .*.swp
 .nyc_output/
 package-lock.json
+.idea

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ const phaseGeneratePermutations = require('./lib/phase/permutation');
 function parseYaml(yaml) {
     // If no yaml exists, throw error
     if (!yaml) {
-        return Promise.reject('screwdriver.yaml does not exist. Please ' +
-        'create a screwdriver.yaml and try to rerun your build.');
+        return Promise.reject(new Error('screwdriver.yaml does not exist. Please '
+        + 'create a screwdriver.yaml and try to rerun your build.'));
     }
 
     return new Promise((resolve) => {
@@ -79,7 +79,7 @@ module.exports = function configParser(yaml, templateFactory, buildClusterFactor
             annotations: {},
             jobs: {
                 main: [{
-                    image: 'node:6',
+                    image: 'node:10',
                     commands: [{
                         name: 'config-parse-error',
                         command: `echo "${err}"; exit 1`

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -10,13 +10,11 @@ const clone = require('clone');
  * @return {Array}                  List of errors or null if no error
  */
 function checkAdditionalRules(doc) {
-    let steps = [];
     const errors = [];
 
     Object.keys(doc.jobs).forEach((job) => {
+        const { steps } = doc.jobs[job];
         const stepList = [];
-
-        steps = doc.jobs[job].steps;
 
         if (steps) {
             for (let i = 0; i < steps.length; i += 1) {
@@ -126,7 +124,7 @@ function merge(newJob, oldJob, fromTemplate) {
         }, {});
 
         for (let i = 0; i < newJob.steps.length; i += 1) {
-            stepName = Object.keys(newJob.steps[i])[0];
+            [stepName] = Object.keys(newJob.steps[i]);
             preStepName = `pre${stepName}`;
             postStepName = `post${stepName}`;
 
@@ -231,8 +229,8 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
 
             // If template.images contains a label match for the image defined in the job
             // set the job image to the respective template image
-            if (typeof template.images !== 'undefined' &&
-                typeof template.images[newJob.image] !== 'undefined') {
+            if (typeof template.images !== 'undefined'
+                && typeof template.images[newJob.image] !== 'undefined') {
                 newJob.image = template.images[newJob.image];
             }
 

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -33,13 +33,11 @@ function validateBuildClusterAnnotation(doc, buildClusterFactory) {
 
     if (buildClusterName && buildClusterFactory) {
         return buildClusterFactory.list()
-            .then(buildClusters => buildClusters.some(buildCluster =>
-                buildCluster.name === buildClusterName
-            ))
+            .then(buildClusters => buildClusters.some(cluster => cluster.name === buildClusterName))
             .then((hasValidBuildCluster) => {
                 if (!hasValidBuildCluster) {
-                    return [`Annotation "${buildClusterAnnotation}": ` +
-                        `${buildClusterName} is not a valid build cluster`];
+                    return [`Annotation "${buildClusterAnnotation}": `
+                        + `${buildClusterName} is not a valid build cluster`];
                 }
 
                 return [];
@@ -69,9 +67,9 @@ function validateJobMatrix(job, prefix) {
     const environmentSize = Object.keys(matrix).length + userEnv.length;
 
     if (environmentSize > MAX_ENVIRONMENT_VARS) {
-        errors.push(`${prefix}: "environment" and "matrix" can only have a combined ` +
-            ` maxiumum of ${MAX_ENVIRONMENT_VARS} environment variables defined ` +
-            `(currently ${environmentSize})`);
+        errors.push(`${prefix}: "environment" and "matrix" can only have a combined `
+            + ` maxiumum of ${MAX_ENVIRONMENT_VARS} environment variables defined `
+            + `(currently ${environmentSize})`);
     }
 
     Object.keys(matrix).forEach((row) => {
@@ -79,8 +77,8 @@ function validateJobMatrix(job, prefix) {
     });
 
     if (matrixSize > MAX_PERMUTATIONS) {
-        errors.push(`${prefix}: "matrix" cannot contain >${MAX_PERMUTATIONS} permutations ` +
-            `(currently ${matrixSize})`);
+        errors.push(`${prefix}: "matrix" cannot contain >${MAX_PERMUTATIONS} permutations `
+            + `(currently ${matrixSize})`);
     }
 
     return errors;

--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -11,13 +11,11 @@ const SCHEMA_CONFIG = require('screwdriver-data-schema').config.base.config;
  * @return {Array}                List of errors
  */
 function checkAdditionalRules(data) {
-    let steps = [];
     const errors = [];
 
     Object.keys(data.jobs).forEach((job) => {
         let firstUserTeardownStep = -1;
-
-        steps = data.jobs[job].steps;
+        const { steps } = data.jobs[job];
 
         if (steps) { // if there are user-defined steps
             for (let i = 0; i < steps.length; i += 1) {

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   },
   "engine-strict": true,
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.2.0",
     "eslint": "^4.19.1",
-    "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
-    "sinon": "^2.4.1"
+    "eslint-config-screwdriver": "^4.0.0",
+    "jenkins-mocha": "^7.0.0",
+    "sinon": "^7.3.2"
   },
   "dependencies": {
     "clone": "^2.1.2",

--- a/test/data/bad-build-cluster.json
+++ b/test/data/bad-build-cluster.json
@@ -3,7 +3,7 @@
     "jobs": {
         "main": [
             {
-                "image": "node:6",
+                "image": "node:10",
                 "commands": [
                     {
                         "name": "config-parse-error",

--- a/test/data/pipeline-cache-nonexist-job.json
+++ b/test/data/pipeline-cache-nonexist-job.json
@@ -3,7 +3,7 @@
     "jobs": {
         "main": [
             {
-                "image": "node:6",
+                "image": "node:10",
                 "commands": [
                     {
                         "name": "config-parse-error",


### PR DESCRIPTION
## Context
The image of a default error workflow and devDependencies are old.

## Objective
This PR upgrades devDependencies and the image of config-parse-error to `node:10`.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
