### PR TITLE
fix(1722): enable to use >= node8

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     }
   },
   "engines": {
-    "node": "^8.0.0"
+    "node": ">=8.16.0"
   },
   "engine-strict": true,
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^4.0.0",
-    "jenkins-mocha": "^7.0.0",
+    "jenkins-mocha": "^8.0.0",
     "sinon": "^7.3.2"
   },
   "dependencies": {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We should update to Node.js version. But this package may prevent updating.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR enables to use >= node 8.16.0 which is latest version of node 8.x.

## References
- https://github.com/screwdriver-cd/screwdriver/issues/1722
- https://nodejs.org/dist/latest-v8.x/
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
