### PR TITLE
feat(1091): add template id into job on config parse

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -227,6 +227,8 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
             merge(newJob, oldJob, true);
             delete newJob.template;
 
+            newJob['templateId'] = template.id
+
             // If template.images contains a label match for the image defined in the job
             // set the job image to the respective template image
             if (typeof template.images !== 'undefined'

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -227,7 +227,7 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
             merge(newJob, oldJob, true);
             delete newJob.template;
 
-            newJob['templateId'] = template.id
+            newJob.templateId = template.id;
 
             // If template.images contains a label match for the image defined in the job
             // set the job image to the respective template image

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -41,6 +41,10 @@ module.exports = validatedDoc => (
                 job.description = doc.jobs[jobName].description;
             }
 
+            if (doc.jobs[jobName].templateId != undefined) {
+                job.templateId = doc.jobs[jobName].templateId;
+            }
+
             // If has the requires/blockedby/freezeWindows key, then set it
             if (doc.jobs[jobName].requires !== undefined) {
                 job.requires = doc.jobs[jobName].requires;

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -41,7 +41,7 @@ module.exports = validatedDoc => (
                 job.description = doc.jobs[jobName].description;
             }
 
-            if (doc.jobs[jobName].templateId != undefined) {
+            if (doc.jobs[jobName].templateId !== undefined) {
                 job.templateId = doc.jobs[jobName].templateId;
             }
 

--- a/test/data/basic-job-with-images.json
+++ b/test/data/basic-job-with-images.json
@@ -23,7 +23,8 @@
         },
         "image": "node:5",
         "secrets": [],
-        "settings": {}
+        "settings": {},
+        "templateId": 9
       }
     ],
     "publish": [

--- a/test/data/basic-job-with-template-override-steps-teardown.json
+++ b/test/data/basic-job-with-template-override-steps-teardown.json
@@ -45,7 +45,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "templateId": 4
         }]
     },
     "workflowGraph": {

--- a/test/data/basic-job-with-template-override-steps-template-teardown.json
+++ b/test/data/basic-job-with-template-override-steps-template-teardown.json
@@ -45,7 +45,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "templateId": 4
         }]
     },
     "workflowGraph": {

--- a/test/data/basic-job-with-template-override-steps.json
+++ b/test/data/basic-job-with-template-override-steps.json
@@ -41,7 +41,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "templateId": 7754
         }]
     },
     "workflowGraph": {

--- a/test/data/basic-job-with-template-wrapped-steps.json
+++ b/test/data/basic-job-with-template-wrapped-steps.json
@@ -40,7 +40,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "templateId": 7754
         }]
     },
     "workflowGraph": {

--- a/test/data/basic-job-with-template.json
+++ b/test/data/basic-job-with-template.json
@@ -32,7 +32,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "templateId": 7754
         }],
       "publish": [{
           "annotations": {},
@@ -53,7 +54,8 @@
           "settings": {},
           "requires": [
               "main"
-          ]
+          ],
+          "templateId": 1234
       }]
     },
     "workflowGraph": {

--- a/test/data/template-2.json
+++ b/test/data/template-2.json
@@ -1,4 +1,5 @@
 {
+    "id": 1234,
     "name": "yourtemplate",
     "version": "2",
     "description": "test template",

--- a/test/data/template-with-teardown.json
+++ b/test/data/template-with-teardown.json
@@ -1,4 +1,5 @@
 {
+    "id": 4,
     "name": "mytemplate",
     "version": "1.2.3",
     "description": "test template",

--- a/test/data/template.json
+++ b/test/data/template.json
@@ -1,4 +1,5 @@
 {
+    "id": 7754,
     "name": "mytemplate",
     "version": "1.2.3",
     "description": "test template",

--- a/test/data/templateWithImages.json
+++ b/test/data/templateWithImages.json
@@ -1,4 +1,5 @@
 {
+    "id": 9,
     "namespace": "ImagesTestNamespace",
     "name": "imagestemplate",
     "version": "2",


### PR DESCRIPTION
## Context

Need to add template id to job so metrics about the number of jobs using some template can be aggregated.

## Objective

To set job's templateId to template.id on config parse.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
