### PR TITLE
fix: use ANSI-C quoting for echoing error

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function configParser(
                     image: 'node:10',
                     commands: [{
                         name: 'config-parse-error',
-                        command: `echo "${err}"; exit 1`
+                        command: `echo $'${err}'; exit 1`
                     }],
                     secrets: [],
                     environment: {}

--- a/test/data/bad-build-cluster.json
+++ b/test/data/bad-build-cluster.json
@@ -7,7 +7,7 @@
                 "commands": [
                     {
                         "name": "config-parse-error",
-                        "command": "echo \"Error: Annotation \"screwdriver.cd/buildCluster\": doesnotexist is not a valid build cluster\"; exit 1"
+                        "command": "echo $'Error: Annotation \"screwdriver.cd/buildCluster\": doesnotexist is not a valid build cluster'; exit 1"
                     }
                 ],
                 "secrets": [],

--- a/test/data/pipeline-cache-nonexist-job.json
+++ b/test/data/pipeline-cache-nonexist-job.json
@@ -7,7 +7,7 @@
                 "commands": [
                     {
                         "name": "config-parse-error",
-                        "command": "echo \"Error: Cache is set for non-existing job: badjob\"; exit 1"
+                        "command": "echo $'Error: Cache is set for non-existing job: badjob'; exit 1"
                     }
                 ],
                 "secrets": [],


### PR DESCRIPTION
## Context

double quote is bad when you can inject command

## Objective

use ANSI-C quoting for escaping 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
