### PR TITLE
Add explicit email and slack validation

### DIFF
--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -2,8 +2,8 @@
 
 const Joi = require('joi');
 const SCHEMA_CONFIG = require('screwdriver-data-schema').config.base.config;
-const validateConfigEmail = require('screwdriver-notifications-email').validateConfigEmail;
-const validateConfigSlack = require('screwdriver-notifications-slack').validateConfigSlack;
+const EmailNotifier = require('screwdriver-notifications-email');
+const SlackNotifier = require('screwdriver-notifications-slack');
 
 /**
  * Check if a job has duplicate steps
@@ -62,14 +62,14 @@ module.exports = doc => (
 
             if (doc.shared.settings) {
                 if (doc.shared.settings.email) {
-                    const { error } = validateConfigEmail(doc.shared.settings.email);
+                    const { error } = EmailNotifier.validateConfig(doc.shared.settings.email);
                     if (error) {
                         return reject(error);
                     }
                 }
     
                 if (doc.shared.settings.slack) {
-                    const { error } = validateConfigSlack(doc.shared.settings.slack);
+                    const { error } = SlackNotifier.validateConfig(doc.shared.settings.slack);
                     if (error) {
                         return reject(error);
                     }

--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -2,6 +2,8 @@
 
 const Joi = require('joi');
 const SCHEMA_CONFIG = require('screwdriver-data-schema').config.base.config;
+const validateConfigEmail = require('screwdriver-notifications-email').validateConfigEmail;
+const validateConfigSlack = require('screwdriver-notifications-slack').validateConfigSlack;
 
 /**
  * Check if a job has duplicate steps
@@ -58,6 +60,22 @@ module.exports = doc => (
                 return reject(schemaErr);
             }
 
+            if (doc.shared.settings) {
+                if (doc.shared.settings.email) {
+                    const { error } = validateConfigEmail(doc.shared.settings.email);
+                    if (error) {
+                        return reject(error);
+                    }
+                }
+    
+                if (doc.shared.settings.slack) {
+                    const { error } = validateConfigSlack(doc.shared.settings.slack);
+                    if (error) {
+                        return reject(error);
+                    }
+                }
+            }
+             
             const errors = checkAdditionalRules(data);
 
             if (errors) {


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1574

## Objective

This PR adds explicit slack and email validation by importing them and adding them in the structural validation flow.

## References

screwdriver-cd/screwdriver#1574

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
