### PR TITLE
fix(1864): Fix config-parse-error workflow graph

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function configParser(
             annotations: {},
             jobs: {
                 main: [{
-                    image: 'node:10',
+                    image: 'node:12',
                     commands: [{
                         name: 'config-parse-error',
                         command: `echo ${shellescape([err.toString()])}; exit 1`
@@ -99,11 +99,13 @@ module.exports = function configParser(
                 nodes: [
                     { name: '~pr' },
                     { name: '~commit' },
-                    { name: 'main' }
+                    { name: 'main' },
+                    { name: '~pr:/.*/' }
                 ],
                 edges: [
                     { src: '~pr', dest: 'main' },
-                    { src: '~commit', dest: 'main' }
+                    { src: '~commit', dest: 'main' },
+                    { src: '~pr:/.*/', dest: 'main' }
                 ]
             },
             errors: [err.toString()]

--- a/test/data/bad-build-cluster.json
+++ b/test/data/bad-build-cluster.json
@@ -3,7 +3,7 @@
     "jobs": {
         "main": [
             {
-                "image": "node:10",
+                "image": "node:12",
                 "commands": [
                     {
                         "name": "config-parse-error",
@@ -25,6 +25,9 @@
             },
             {
                 "name": "main"
+            },
+            {
+                "name": "~pr:/.*/"
             }
         ],
         "edges": [
@@ -34,6 +37,10 @@
             },
             {
                 "src": "~commit",
+                "dest": "main"
+            },
+            {
+                "src": "~pr:/.*/",
                 "dest": "main"
             }
         ]

--- a/test/data/pipeline-cache-nonexist-job.json
+++ b/test/data/pipeline-cache-nonexist-job.json
@@ -3,7 +3,7 @@
     "jobs": {
         "main": [
             {
-                "image": "node:10",
+                "image": "node:12",
                 "commands": [
                     {
                         "name": "config-parse-error",
@@ -25,6 +25,9 @@
             },
             {
                 "name": "main"
+            },
+            {
+                "name": "~pr:/.*/"
             }
         ],
         "edges": [
@@ -34,6 +37,10 @@
             },
             {
                 "src": "~commit",
+                "dest": "main"
+            },
+            {
+                "src": "~pr:/.*/",
                 "dest": "main"
             }
         ]

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,14 +30,16 @@ describe('config parser', () => {
                         nodes: [
                             { name: '~pr' },
                             { name: '~commit' },
-                            { name: 'main' }
+                            { name: 'main' },
+                            { name: '~pr:/.*/' }
                         ],
                         edges: [
                             { src: '~pr', dest: 'main' },
-                            { src: '~commit', dest: 'main' }
+                            { src: '~commit', dest: 'main' },
+                            { src: '~pr:/.*/', dest: 'main' }
                         ]
                     });
-                    assert.strictEqual(data.jobs.main[0].image, 'node:10');
+                    assert.strictEqual(data.jobs.main[0].image, 'node:12');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
                     assert.deepEqual(data.jobs.main[0].environment, {});
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
@@ -48,7 +50,7 @@ describe('config parser', () => {
 
         it('returns an error if unparsable yaml', () => parser('foo: :')
             .then((data) => {
-                assert.strictEqual(data.jobs.main[0].image, 'node:10');
+                assert.strictEqual(data.jobs.main[0].image, 'node:12');
                 assert.deepEqual(data.jobs.main[0].secrets, []);
                 assert.deepEqual(data.jobs.main[0].environment, {});
                 assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
@@ -59,7 +61,7 @@ describe('config parser', () => {
         it('returns an error if job has duplicate steps',
             () => parser(loadData('basic-job-with-duplicate-steps.yaml'))
                 .then((data) => {
-                    assert.strictEqual(data.jobs.main[0].image, 'node:10');
+                    assert.strictEqual(data.jobs.main[0].image, 'node:12');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
                     assert.deepEqual(data.jobs.main[0].environment, {});
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
@@ -79,7 +81,7 @@ describe('config parser', () => {
         it('returns an error if multiple documents without hint',
             () => parser('foo: bar\n---\nfoo: baz')
                 .then((data) => {
-                    assert.strictEqual(data.jobs.main[0].image, 'node:10');
+                    assert.strictEqual(data.jobs.main[0].image, 'node:12');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
                     assert.deepEqual(data.jobs.main[0].environment, {});
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
@@ -90,7 +92,7 @@ describe('config parser', () => {
 
         it('picks the document with version hint', () => parser('jobs: {}\n---\nversion: 4')
             .then((data) => {
-                assert.strictEqual(data.jobs.main[0].image, 'node:10');
+                assert.strictEqual(data.jobs.main[0].image, 'node:12');
                 assert.deepEqual(data.jobs.main[0].secrets, []);
                 assert.deepEqual(data.jobs.main[0].environment, {});
                 assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To trigger `main` job when config-parse-error occurs on branch filtering job.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
`main` job is triggered by all PR.

## References

screwdriver-cd/screwdriver#1864
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
