### PR TITLE
feat(1958): Hapi v19 dependencies upgrade. BREAKING CHANGE: v19.x.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const YamlParser = require('js-yaml');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const shellescape = require('shell-escape');
 
 const phaseValidateStructure = require('./lib/phase/structural');
@@ -19,7 +19,7 @@ function parseYaml(yaml) {
     // If no yaml exists, throw error
     if (!yaml) {
         return Promise.reject(new Error('screwdriver.yaml does not exist. Please '
-        + 'create a screwdriver.yaml and try to rerun your build.'));
+            + 'create a screwdriver.yaml and try to rerun your build.'));
     }
 
     return new Promise((resolve) => {
@@ -35,7 +35,7 @@ function parseYaml(yaml) {
 
         if (!doc) {
             throw new YamlParser.YAMLException('Configuration is too ambigious - '
-            + 'contains multiple documents without a version hint');
+                + 'contains multiple documents without a version hint');
         }
 
         return resolve(doc);

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const clone = require('clone');
 
 /**

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Joi = require('joi');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const clone = require('clone');
 const WorkflowParser = require('screwdriver-workflow-parser');
 
@@ -129,13 +129,7 @@ function validateJobSchema(doc) {
         })
         .unknown(true)
         // Add documentation
-        .options({
-            language: {
-                object: {
-                    min: 'requires at least one step'
-                }
-            }
-        });
+        .description('requires at least one step');
 
     // Validate jobs contain required minimum fields
     Object.keys(doc.jobs).forEach((jobName) => {

--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const TinyTim = require('tinytim');
 const clone = require('clone');
 const keymbinatorial = require('keymbinatorial');

--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Joi = require('joi');
 const SCHEMA_CONFIG = require('screwdriver-data-schema').config.base.config;
 
 /**
@@ -49,22 +48,22 @@ function checkAdditionalRules(data) {
  * @param   {Object}   doc      Direct document from YAML parsing
  * @returns {Promise}
  */
-module.exports = doc => (
-    new Promise((resolve, reject) => {
-        Joi.validate(doc, SCHEMA_CONFIG, {
+async function structuralValidation(doc) {
+    try {
+        const data = await SCHEMA_CONFIG.validateAsync(doc, {
             abortEarly: false
-        }, (schemaErr, data) => {
-            if (schemaErr) {
-                return reject(schemaErr);
-            }
-
-            const errors = checkAdditionalRules(data);
-
-            if (errors) {
-                return reject(errors);
-            }
-
-            return resolve(data);
         });
-    })
-);
+
+        const errors = checkAdditionalRules(data);
+
+        if (errors) {
+            throw errors;
+        }
+
+        return data;
+    } catch (err) {
+        throw err;
+    }
+}
+
+module.exports = structuralValidation;

--- a/lib/phase/structural.js
+++ b/lib/phase/structural.js
@@ -49,21 +49,17 @@ function checkAdditionalRules(data) {
  * @returns {Promise}
  */
 async function structuralValidation(doc) {
-    try {
-        const data = await SCHEMA_CONFIG.validateAsync(doc, {
-            abortEarly: false
-        });
+    const data = await SCHEMA_CONFIG.validateAsync(doc, {
+        abortEarly: false
+    });
 
-        const errors = checkAdditionalRules(data);
+    const errors = checkAdditionalRules(data);
 
-        if (errors) {
-            throw errors;
-        }
-
-        return data;
-    } catch (err) {
-        throw err;
+    if (errors) {
+        throw errors;
     }
+
+    return data;
 }
 
 module.exports = structuralValidation;

--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.0.4",
     "clone": "^2.1.2",
-    "hoek": "^5.0.4",
-    "joi": "^13.7.0",
+    "joi": "^17.1.1",
     "js-yaml": "^3.13.0",
     "keymbinatorial": "^1.1.5",
-    "screwdriver-data-schema": "^19.1.1",
-    "screwdriver-workflow-parser": "^2.0.0",
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
+    "screwdriver-workflow-parser": "git://github.com/screwdriver-cd/workflow-parser.git#hapi-v19",
     "shell-escape": "^0.2.0",
     "tinytim": "^0.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-config-parser",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Node module for parsing screwdriver.yaml configurations",
   "main": "index.js",
   "scripts": {
@@ -53,8 +53,8 @@
     "joi": "^17.1.1",
     "js-yaml": "^3.13.0",
     "keymbinatorial": "^1.1.5",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
-    "screwdriver-workflow-parser": "git://github.com/screwdriver-cd/workflow-parser.git#hapi-v19",
+    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-workflow-parser": "3.0.0",
     "shell-escape": "^0.2.0",
     "tinytim": "^0.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -44,7 +44,7 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "4.0.0",
-    "jenkins-mocha": "^8.0.0",
+    "mocha": "^8.1.1",
     "sinon": "^7.5.0"
   },
   "dependencies": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -124,7 +124,7 @@ describe('config parser', () => {
                 () => parser(loadData('bad-step-name.yaml'))
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
-                            /foo bar" only supports the following characters A-Z,a-z,0-9,-,_/);
+                            /.foo bar" only supports the following characters A-Z,a-z,0-9,-,_';/);
                     }));
 
             it('returns an error if teardown step is not at the end',
@@ -140,7 +140,7 @@ describe('config parser', () => {
                 () => parser(loadData('bad-environment-name.yaml'))
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
-                            /foo bar" only supports uppercase letters,/);
+                            /"jobs.main.environment.foo bar" only supports uppercase letters,/);
                     }));
         });
 
@@ -148,7 +148,7 @@ describe('config parser', () => {
             it('returns an error if bad matrix name', () => parser(loadData('bad-matrix-name.yaml'))
                 .then((data) => {
                     assert.match(data.jobs.main[0].commands[0].command,
-                        /foo bar" only supports uppercase letters,/);
+                        /"jobs.main.matrix.foo bar" only supports uppercase letters,/);
                 }));
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -124,7 +124,7 @@ describe('config parser', () => {
                 () => parser(loadData('bad-step-name.yaml'))
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
-                            /"foo bar" only supports the following characters A-Z,a-z,0-9,-,_/);
+                            /foo bar" only supports the following characters A-Z,a-z,0-9,-,_/);
                     }));
 
             it('returns an error if teardown step is not at the end',
@@ -140,7 +140,7 @@ describe('config parser', () => {
                 () => parser(loadData('bad-environment-name.yaml'))
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
-                            /"foo bar" only supports uppercase letters,/);
+                            /foo bar" only supports uppercase letters,/);
                     }));
         });
 
@@ -148,7 +148,7 @@ describe('config parser', () => {
             it('returns an error if bad matrix name', () => parser(loadData('bad-matrix-name.yaml'))
                 .then((data) => {
                     assert.match(data.jobs.main[0].commands[0].command,
-                        /"foo bar" only supports uppercase letters,/);
+                        /foo bar" only supports uppercase letters,/);
                 }));
         });
 
@@ -380,7 +380,7 @@ describe('config parser', () => {
                 pipelineId
             ).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
-                    /"steps" must contain at least 1 items/);
+                    /"jobs.main.steps" must contain at least 1 items/);
             }));
 
         it('returns an error if too many environment variables',


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR upgrades hapi and node fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
