### PR TITLE
fix(2211): Error on validating sd.yaml that has cache-disable setting

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -374,6 +374,10 @@ module.exports = (parsedDoc, templateFactory) => {
     if (parsedDoc.cache) {
         doc.jobs = flattenCacheSettings(parsedDoc.cache, doc.jobs);
         delete doc.cache;
+    } else {
+        Object.keys(doc.jobs).forEach((jobName) => {
+            delete doc.jobs[jobName].cache;
+        });
     }
 
     // Flatten templates

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -376,7 +376,9 @@ module.exports = (parsedDoc, templateFactory) => {
         delete doc.cache;
     } else {
         Object.keys(doc.jobs).forEach((jobName) => {
-            delete doc.jobs[jobName].cache;
+            if (doc.jobs[jobName].cache !== undefined) {
+                throw new Error('Cache disable/enable is set without the cache setting itself.');
+            }
         });
     }
 

--- a/test/data/pipeline-cache-false-nonexist-job.json
+++ b/test/data/pipeline-cache-false-nonexist-job.json
@@ -1,0 +1,49 @@
+{
+    "annotations": {},
+    "jobs": {
+        "main": [
+            {
+                "image": "node:4",
+                "requires": [
+                    "~pr",
+                    "~commit"
+                ],
+                "annotations": {},
+                "commands": [
+                    {
+                        "command": "npm install",
+                        "name": "install"
+                    }
+                ],
+                "secrets": [],
+                "settings": {},
+                "environment": {}
+            }
+        ]
+    },
+    "parameters": {},
+    "subscribe": {},
+    "workflowGraph": {
+        "nodes": [
+            {
+                "name": "~pr"
+            },
+            {
+                "name": "~commit"
+            },
+            {
+                "name": "main"
+            }
+        ],
+        "edges": [
+            {
+                "src": "~pr",
+                "dest": "main"
+            },
+            {
+                "src": "~commit",
+                "dest": "main"
+            }
+        ]
+    }
+}

--- a/test/data/pipeline-cache-false-nonexist-job.json
+++ b/test/data/pipeline-cache-false-nonexist-job.json
@@ -3,26 +3,18 @@
     "jobs": {
         "main": [
             {
-                "image": "node:4",
-                "requires": [
-                    "~pr",
-                    "~commit"
-                ],
-                "annotations": {},
+                "image": "node:12",
                 "commands": [
                     {
-                        "command": "npm install",
-                        "name": "install"
+                        "name": "config-parse-error",
+                        "command": "echo 'Error: Cache disable/enable is set without the cache setting itself.'; exit 1"
                     }
                 ],
                 "secrets": [],
-                "settings": {},
                 "environment": {}
             }
         ]
     },
-    "parameters": {},
-    "subscribe": {},
     "workflowGraph": {
         "nodes": [
             {
@@ -33,6 +25,9 @@
             },
             {
                 "name": "main"
+            },
+            {
+                "name": "~pr:/.*/"
             }
         ],
         "edges": [
@@ -43,7 +38,14 @@
             {
                 "src": "~commit",
                 "dest": "main"
+            },
+            {
+                "src": "~pr:/.*/",
+                "dest": "main"
             }
         ]
-    }
+    },
+    "errors": [
+        "Error: Cache disable/enable is set without the cache setting itself."
+    ]
 }

--- a/test/data/pipeline-cache-false-nonexist-job.yaml
+++ b/test/data/pipeline-cache-false-nonexist-job.yaml
@@ -1,0 +1,9 @@
+jobs:
+    main:
+        image: node:4
+        steps:
+            - install: npm install
+        requires:
+            - ~pr
+            - ~commit
+        cache: false

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -512,6 +512,19 @@ describe('config parser', () => {
                 ));
             }));
 
+        it('ignore cache false on the job when the cache config does not exist',
+            () => parser(
+                loadData('pipeline-cache-false-nonexist-job.yaml'),
+                templateFactoryMock,
+                buildClusterFactoryMock,
+                triggerFactory,
+                pipelineId
+            ).then((data) => {
+                assert.deepEqual(data, JSON.parse(
+                    loadData('pipeline-cache-false-nonexist-job.json')
+                ));
+            }));
+
         it('validates build cluster',
             () => parser(
                 loadData('build-cluster.yaml'),


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix https://github.com/screwdriver-cd/screwdriver/issues/2211

When the object base cache settings does not exist, the cache-disable settings (true/false) keep remains as shape of boolean. It is validated as [output](https://github.com/screwdriver-cd/screwdriver/blob/e698e39916dc84922f3c0e21563cf10c4a379669/plugins/validator.js#L40) of parser, but it is not match with the shape of [data-schema](https://github.com/screwdriver-cd/data-schema/blob/3c7ba87df825a47291454c955782c61644599158/api/validator.js#L27).

This PR fixes the validation error by deleting data which is no need to exists for validation. 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The 500 error does not occur even if cache-disable settings(true/false) exists without cache settings(object)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2211

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
