### PR TITLE
feat(2174): [2] Merge steps with annotations

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -230,8 +230,8 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
 
             // merge shared steps into oldJob
             if (sharedConfig.steps
-                && (oldJob.annotations['screwdriver.cd/mergeStep']
-                || template.annotations['screwdriver.cd/mergeStep'])) {
+                && (oldJob.annotations['screwdriver.cd/mergeSharedSteps']
+                || template.annotations['screwdriver.cd/mergeSharedSteps'])) {
                 // convert steps from oldJob from array to object for faster lookup
                 const oldSteps = oldJob.steps.reduce((obj, item) => {
                     const key = Object.keys(item)[0];

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -231,7 +231,10 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
             // merge shared steps into oldJob
             if (sharedConfig.steps
                 && ((oldJob.annotations && oldJob.annotations['screwdriver.cd/mergeSharedSteps'])
-                || (template.annotations && template.annotations['screwdriver.cd/mergeSharedSteps']))) {
+                || ((oldJob.annotations === undefined
+                    || oldJob.annotations['screwdriver.cd/mergeSharedSteps'] === undefined)
+                    && template.annotations
+                    && template.annotations['screwdriver.cd/mergeSharedSteps']))) {
                 // convert steps from oldJob from array to object for faster lookup
                 const oldSteps = oldJob.steps.reduce((obj, item) => {
                     const key = Object.keys(item)[0];

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -200,7 +200,7 @@ function flattenSharedIntoJobs(shared, jobs) {
  * @param  {TemplateFactory}  templateFactory   Template Factory to get templates
  * @return {Promise}
  */
-function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
+function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, sharedConfig) {
     const oldJob = jobConfig;
 
     // Try to get the template
@@ -228,6 +228,26 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
                 SD_TEMPLATE_VERSION: template.version
             });
 
+            // merge shared steps into oldJob
+            if (sharedConfig.steps
+                && (oldJob.annotations['screwdriver.cd/mergeStep']
+                || template.annotations['screwdriver.cd/mergeStep'])) {
+                // convert steps from oldJob from array to object for faster lookup
+                const oldSteps = oldJob.steps.reduce((obj, item) => {
+                    const key = Object.keys(item)[0];
+
+                    obj[key] = item[key];
+
+                    return obj;
+                }, {});
+
+                for (let i = 0; i < sharedConfig.steps.length; i += 1) {
+                    if (!oldSteps[Object.keys(sharedConfig.steps[i])]) {
+                        oldJob.steps.push(sharedConfig.steps[i]);
+                    }
+                }
+            }
+
             merge(newJob, oldJob, true);
             delete newJob.template;
 
@@ -250,13 +270,14 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory) {
  * Goes through each job and if template is specified, then merge into job config
  *
  * @method flattenTemplates
- * @param  {Object}           jobs              Object with all the jobs
+ * @param  {Object}           doc               Document that went through structural parsing
  * @param  {TemplateFactory}  templateFactory   Template Factory to get templates
  * @return {Promise}          Resolves to new object with jobs after merging templates
  */
-function flattenTemplates(jobs, templateFactory) {
+function flattenTemplates(doc, templateFactory) {
     const newJobs = {};
     const templates = [];
+    const { jobs, shared } = doc;
 
     // eslint-disable-next-line
     Object.keys(jobs).forEach((jobName) => {
@@ -265,7 +286,9 @@ function flattenTemplates(jobs, templateFactory) {
 
         // If template is specified, then merge
         if (templateConfig) {
-            templates.push(mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory));
+            templates.push(mergeTemplateIntoJob(
+                jobName, jobConfig, newJobs, templateFactory, shared
+            ));
         } else {
             newJobs[jobName] = jobConfig; // Otherwise just use jobConfig
         }
@@ -369,7 +392,6 @@ module.exports = (parsedDoc, templateFactory) => {
 
     // Flatten shared into jobs
     doc.jobs = flattenSharedIntoJobs(parsedDoc.shared, parsedDoc.jobs);
-    delete doc.shared;
 
     if (parsedDoc.cache) {
         doc.jobs = flattenCacheSettings(parsedDoc.cache, doc.jobs);
@@ -383,7 +405,7 @@ module.exports = (parsedDoc, templateFactory) => {
     }
 
     // Flatten templates
-    return flattenTemplates(doc.jobs, templateFactory)
+    return flattenTemplates(doc, templateFactory)
         // Clean through the job values
         .then(cleanComplexEnvironment)
         // Convert steps into proper expanded output
@@ -391,6 +413,7 @@ module.exports = (parsedDoc, templateFactory) => {
         // Append flattened jobs and return flattened doc
         .then((jobs) => {
             doc.jobs = jobs;
+            delete doc.shared;
 
             const errors = checkAdditionalRules(doc);
 

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -230,8 +230,8 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
 
             // merge shared steps into oldJob
             if (sharedConfig.steps
-                && (oldJob.annotations['screwdriver.cd/mergeSharedSteps']
-                || template.annotations['screwdriver.cd/mergeSharedSteps'])) {
+                && ((oldJob.annotations && oldJob.annotations['screwdriver.cd/mergeSharedSteps'])
+                || (template.annotations && template.annotations['screwdriver.cd/mergeSharedSteps']))) {
                 // convert steps from oldJob from array to object for faster lookup
                 const oldSteps = oldJob.steps.reduce((obj, item) => {
                     const key = Object.keys(item)[0];

--- a/test/data/basic-job-with-shared-and-template-override-steps.json
+++ b/test/data/basic-job-with-shared-and-template-override-steps.json
@@ -4,7 +4,7 @@
     "jobs": {
         "main": [{
             "annotations": {
-                "screwdriver.cd/deepMergeStep": true
+                "screwdriver.cd/mergeSharedSteps": true
             },
             "image": "node:4",
             "commands": [

--- a/test/data/basic-job-with-shared-and-template-override-steps.json
+++ b/test/data/basic-job-with-shared-and-template-override-steps.json
@@ -1,0 +1,57 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {
+                "screwdriver.cd/deepMergeStep": true
+            },
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "pretest",
+                    "command": "echo pre-test"
+                },
+                {
+                    "name": "test",
+                    "command": "echo 'my job is overriding this step'"
+                }
+            ],
+            "environment": {
+                "FOO": "from template",
+                "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-job-with-shared-and-template-override-steps.yaml
+++ b/test/data/basic-job-with-shared-and-template-override-steps.yaml
@@ -5,7 +5,7 @@ shared:
 jobs:
   main:
     annotations:
-      screwdriver.cd/mergeStep: true
+      screwdriver.cd/mergeSharedSteps: true
     template: mytemplate@1.2.3
     steps:
       - test: echo 'my job is overriding this step'

--- a/test/data/basic-job-with-shared-and-template-override-steps.yaml
+++ b/test/data/basic-job-with-shared-and-template-override-steps.yaml
@@ -1,0 +1,14 @@
+shared:
+  steps:
+    - pretest: echo pre-test
+    - predummy: echo 'this step is not merged'
+jobs:
+  main:
+    annotations:
+      screwdriver.cd/mergeStep: true
+    template: mytemplate@1.2.3
+    steps:
+      - test: echo 'my job is overriding this step'
+    requires:
+      - ~pr
+      - ~commit

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -298,6 +298,14 @@ describe('config parser', () => {
                     data, JSON.parse(loadData('basic-job-with-template-override-steps.json'))
                 )));
 
+            it('flattens templates with shared and job stes ',
+                () => parser(
+                    loadData('basic-job-with-shared-and-template-override-steps.yaml'),
+                    templateFactoryMock
+                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                    'basic-job-with-shared-and-template-override-steps.json'
+                )))));
+
             it('template-teardown is merged into steps', () => {
                 templateFactoryMock.getTemplate = sinon.stub().resolves(
                     JSON.parse(loadData('template-with-teardown.json'))

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -298,7 +298,7 @@ describe('config parser', () => {
                     data, JSON.parse(loadData('basic-job-with-template-override-steps.json'))
                 )));
 
-            it('flattens templates with shared and job stes ',
+            it('flattens templates with shared and job steps ',
                 () => parser(
                     loadData('basic-job-with-shared-and-template-override-steps.yaml'),
                     templateFactoryMock


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If annotation `screwdriver.cd/mergeStep` is true, steps defined in shared field are not overridden but merged with job defined steps.
This feature only enable when template is used.

The test will pass after [data-schema](https://github.com/screwdriver-cd/data-schema/pull/418) is merged.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: screwdriver-cd/screwdriver#2174
data-schema: https://github.com/screwdriver-cd/data-schema/pull/418

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
