### PR TITLE
[2]feat(1815): add validateTemplateVersion

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function validateReservedAnnotation(doc) {
 }
 
 /**
- * Check that the version is specify
+ * Check that the version is specified
  * @method validateTemplateVersion
  * @param  {Object}           doc               Document that went through structural parsing
  * @param  {TemplateFactory}  templateFactory   Template Factory to get templates

--- a/test/data/warn-job-template-version.yaml
+++ b/test/data/warn-job-template-version.yaml
@@ -1,0 +1,5 @@
+jobs:
+    main:
+        template: foo/bar
+    sub:
+        template: foo/baz

--- a/test/data/warn-shared-template-version.yaml
+++ b/test/data/warn-shared-template-version.yaml
@@ -1,0 +1,6 @@
+shared:
+    template: foo/bar
+
+jobs:
+    main:
+        requires: []


### PR DESCRIPTION
## Context
If versionOrTag is not specified with the template, the validator will output a warning.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Checks if versionOrTag is specified with the template. If it is not, add a warning message to `warnMessages`.
The name `warnAnnotations` is not appropriate, so it has been changed to `warnMessages`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1815

[1] : https://github.com/screwdriver-cd/models/pull/484
[2] : https://github.com/screwdriver-cd/config-parser/pull/116  (This PR)
[3] : https://github.com/screwdriver-cd/ui/pull/650
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
