### PR TITLE
fix(2328): Support overriding shared settings

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -183,6 +183,11 @@ function flattenSharedIntoJobs(shared, jobs) {
             }
         });
 
+        // Replace settings if empty object
+        if (Hoek.deepEqual(oldJob.settings, {})) {
+            newJob.settings = oldJob.settings;
+        }
+
         merge(newJob, oldJob);
         newJobs[jobName] = newJob;
     });

--- a/test/data/basic-shared-project-empty-settings.json
+++ b/test/data/basic-shared-project-empty-settings.json
@@ -1,0 +1,194 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish"
+                    }
+                ],
+                "environment": {
+                    "FOO": "bar",
+                    "BAR": "foo",
+                    "DIRECTORY": "c"
+                },
+                "secrets": [
+                    "GIT_KEY"
+                ],
+                "settings": {},
+                "requires": [
+                    "~pr",
+                    "~commit"
+                ]
+            },
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish"
+                    }
+                ],
+                "environment": {
+                    "FOO": "bar",
+                    "BAR": "foo",
+                    "DIRECTORY": "d"
+                },
+                "secrets": [
+                    "GIT_KEY"
+                ],
+                "settings": {},
+                "requires": [
+                    "~pr",
+                    "~commit"
+                ]
+            }
+        ],
+        "foobar": [
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "step-1",
+                        "command": "hostname"
+                    }
+                ],
+                "environment": {
+                    "FOO": "ban",
+                    "BAZ": "foo",
+                    "VERSION": "1",
+                    "DIRECTORY": "a"
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ],
+                "settings": {
+                    "email": "foo@example.com",
+                    "hipchat": "room_a"
+                },
+                "requires": [
+                    "main"
+                ]
+            },
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "step-1",
+                        "command": "hostname"
+                    }
+                ],
+                "environment": {
+                    "FOO": "ban",
+                    "BAZ": "foo",
+                    "VERSION": "1",
+                    "DIRECTORY": "b"
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ],
+                "settings": {
+                    "email": "foo@example.com",
+                    "hipchat": "room_a"
+                },
+                "requires": [
+                    "main"
+                ]
+            },
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "step-1",
+                        "command": "hostname"
+                    }
+                ],
+                "environment": {
+                    "FOO": "ban",
+                    "BAZ": "foo",
+                    "VERSION": "2",
+                    "DIRECTORY": "a"
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ],
+                "settings": {
+                    "email": "foo@example.com",
+                    "hipchat": "room_a"
+                },
+                "requires": [
+                    "main"
+                ]
+            },
+            {
+                "annotations": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "step-1",
+                        "command": "hostname"
+                    }
+                ],
+                "environment": {
+                    "FOO": "ban",
+                    "BAZ": "foo",
+                    "VERSION": "2",
+                    "DIRECTORY": "b"
+                },
+                "secrets": [
+                    "GIT_KEY",
+                    "NPM_TOKEN"
+                ],
+                "settings": {
+                    "email": "foo@example.com",
+                    "hipchat": "room_a"
+                },
+                "requires": [
+                    "main"
+                ]
+            }
+        ]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "foobar" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "foobar" }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-shared-project-empty-settings.yaml
+++ b/test/data/basic-shared-project-empty-settings.yaml
@@ -1,0 +1,38 @@
+shared:
+    image: node:4
+    steps:
+        - hostname
+    environment:
+        FOO: bar
+    matrix:
+        VERSION: [1,2]
+        DIRECTORY: [a,b]
+    secrets:
+        - GIT_KEY
+    settings:
+        email: foo@example.com
+        hipchat: room_a
+        
+jobs:
+    main:
+        image: node:4
+        steps:
+            - install: npm install
+            - test: npm test
+            - publish: npm publish
+        environment:
+            BAR: foo
+        matrix:
+            DIRECTORY: [c,d]
+        settings: {}
+        requires:
+            - ~pr
+            - ~commit
+    foobar:
+        environment:
+            BAZ: foo
+            FOO: ban
+        secrets:
+            - NPM_TOKEN
+        requires:
+            - main

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -178,6 +178,14 @@ describe('config parser', () => {
                     assert.deepEqual(data, JSON.parse(loadData('basic-shared-project.json')));
                 }));
 
+        it('replaces settings if empty object',
+            () => parser(loadData('basic-shared-project-empty-settings.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data, JSON.parse(
+                        loadData('basic-shared-project-empty-settings.json')
+                    ));
+                }));
+
         it('flattens complex environments', () => parser(loadData('complex-environment.yaml'))
             .then((data) => {
                 assert.deepEqual(data, JSON.parse(loadData('complex-environment.json')));


### PR DESCRIPTION
## Context

Sometimes users want to override shared settings in their individual jobs.

## Objective

This PR keeps settings as empty object if job specifies it.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2328

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
