### PR TITLE
feat(2319): Support order for template composition

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,12 @@ module.exports = function configParser(
         .then((parsedDoc) => {
             warnMessages = warnMessages.concat(validateTemplateVersion(parsedDoc, templateFactory));
 
-            return phaseFlatten(parsedDoc, templateFactory);
+            return phaseFlatten(parsedDoc, templateFactory)
+                .then(({ warnings, flattenedDoc }) => {
+                    warnMessages = warnMessages.concat(warnings);
+
+                    return flattenedDoc;
+                });
         })
         // Functionality validation
         .then(flattenedDoc => phaseValidateFunctionality(flattenedDoc,

--- a/index.js
+++ b/index.js
@@ -94,32 +94,6 @@ function validateReservedAnnotation(doc) {
 }
 
 /**
- * Check that order is only used with template
- * @method validateOrderAndTemplate
- * @param  {Object}           doc               Document that went through structural parsing
- * @return {Array}                              List of warnings
- */
-function validateOrderAndTemplate(doc) {
-    let warnings = [];
-
-    let template = Hoek.reach(doc.shared, 'template');
-
-    Object.keys(doc.jobs).forEach((jobName) => {
-        const order = Hoek.reach(doc.jobs[jobName], 'order', { default: [] });
-
-        template = Hoek.reach(doc.jobs[jobName], 'template');
-
-        if (order.length > 0 && template === undefined) {
-            warnings = warnings.concat(
-                `"order" in ${jobName} job cannot be used without "template"`
-            );
-        }
-    });
-
-    return warnings;
-}
-
-/**
  * Check that the version is specified
  * @method validateTemplateVersion
  * @param  {Object}           doc               Document that went through structural parsing
@@ -180,7 +154,6 @@ module.exports = function configParser(
         // Flatten structures
         .then((parsedDoc) => {
             warnMessages = warnMessages.concat(validateTemplateVersion(parsedDoc, templateFactory));
-            warnMessages = warnMessages.concat(validateOrderAndTemplate(parsedDoc));
 
             return phaseFlatten(parsedDoc, templateFactory)
                 .then(({ warnings, flattenedDoc }) => {

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -348,6 +348,17 @@ function flattenTemplates(doc, templateFactory) {
     Object.keys(jobs).forEach((jobName) => {
         const jobConfig = clone(jobs[jobName]);
         const templateConfig = jobConfig.template;
+        const order = jobConfig.order || [];
+        let warnMessages = [];
+
+        // Validate order is used with template
+        if (order.length > 0 && templateConfig === undefined) {
+            warnMessages = warnMessages.concat(
+                `"order" in ${jobName} job cannot be used without "template"`
+            );
+
+            templates.push(warnMessages);
+        }
 
         // If template is specified, then merge
         if (templateConfig) {

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -92,6 +92,10 @@ function merge(newJob, oldJob, fromTemplate) {
         newJob.cache = oldJob.cache;
     }
 
+    if (oldJob.order) {
+        newJob.order = [].concat(oldJob.order);
+    }
+
     // Merge secrets
     const newSecrets = newJob.secrets || [];
     const oldSecrets = oldJob.secrets || [];
@@ -107,7 +111,56 @@ function merge(newJob, oldJob, fromTemplate) {
     newJob.secrets = [...new Set([...newSecrets, ...oldSecrets])];
     newJob.sourcePaths = [...new Set([...newsourcePaths, ...oldsourcePaths])];
 
-    if (fromTemplate && oldJob.steps) {
+    let warnings = [];
+
+    // Use "order" to get steps, ignore all other steps;
+    // current template has precedence over external template
+    if (fromTemplate && oldJob.order) {
+        let stepName;
+        const mergedSteps = [];
+        const teardownSteps = [];
+
+        // Convert steps from array to object for faster lookup
+        const oldSteps = oldJob.steps.reduce((obj, item) => {
+            const key = Object.keys(item)[0];
+
+            obj[key] = item[key];
+
+            return obj;
+        }, {});
+        const newSteps = newJob.steps.reduce((obj, item) => {
+            const key = Object.keys(item)[0];
+
+            obj[key] = item[key];
+
+            return obj;
+        }, {});
+
+        for (let i = 0; i < oldJob.order.length; i += 1) {
+            let step;
+
+            stepName = oldJob.order[i];
+
+            if (oldSteps && oldSteps[stepName]) {
+                step = { [stepName]: oldSteps[stepName] };
+            } else if (newSteps && newSteps[stepName]) {
+                step = { [stepName]: newSteps[stepName] };
+            } else {
+                warnings = warnings.concat(`${stepName} step definition not found; skipping`);
+            }
+
+            if (step) {
+                if (stepName.startsWith('teardown-')) {
+                    teardownSteps.push(step);
+                } else {
+                    mergedSteps.push(step);
+                }
+            }
+        }
+
+        newJob.steps = mergedSteps.concat(teardownSteps);
+    // Basic step merge with template
+    } else if (fromTemplate && oldJob.steps) {
         let stepName;
         let preStepName;
         let postStepName;
@@ -159,6 +212,8 @@ function merge(newJob, oldJob, fromTemplate) {
 
         newJob.steps = mergedSteps;
     }
+
+    return warnings;
 }
 
 /**
@@ -233,6 +288,8 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
                 SD_TEMPLATE_VERSION: template.version
             });
 
+            let warnings = [];
+
             // merge shared steps into oldJob
             if (sharedConfig.steps
                 && ((oldJob.annotations && oldJob.annotations['screwdriver.cd/mergeSharedSteps'])
@@ -249,14 +306,20 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
                     return obj;
                 }, {});
 
-                for (let i = 0; i < sharedConfig.steps.length; i += 1) {
-                    if (!oldSteps[Object.keys(sharedConfig.steps[i])]) {
-                        oldJob.steps.push(sharedConfig.steps[i]);
+                if (!oldJob.order) {
+                    for (let i = 0; i < sharedConfig.steps.length; i += 1) {
+                        if (!oldSteps[Object.keys(sharedConfig.steps[i])]) {
+                            oldJob.steps.push(sharedConfig.steps[i]);
+                        }
                     }
+                // Merge shared steps with job steps if "order" keyword
+                } else {
+                    oldJob.steps = Hoek.applyToDefaults(sharedConfig.steps, oldJob.steps);
                 }
             }
 
-            merge(newJob, oldJob, true);
+            warnings = merge(newJob, oldJob, true);
+
             delete newJob.template;
 
             newJob.templateId = template.id;
@@ -270,7 +333,7 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
 
             newJobs[jobName] = newJob;
 
-            return null;
+            return warnings;
         });
 }
 
@@ -287,7 +350,6 @@ function flattenTemplates(doc, templateFactory) {
     const templates = [];
     const { jobs, shared } = doc;
 
-    // eslint-disable-next-line
     Object.keys(jobs).forEach((jobName) => {
         const jobConfig = clone(jobs[jobName]);
         const templateConfig = jobConfig.template;
@@ -304,7 +366,7 @@ function flattenTemplates(doc, templateFactory) {
 
     // Wait until all promises are resolved
     return Promise.all(templates)
-        .then(() => newJobs);
+        .then(warnings => ({ warnings: [].concat(...warnings), newJobs }));
 }
 
 /**
@@ -414,13 +476,14 @@ module.exports = (parsedDoc, templateFactory) => {
 
     // Flatten templates
     return flattenTemplates(doc, templateFactory)
-        // Clean through the job values
-        .then(cleanComplexEnvironment)
-        // Convert steps into proper expanded output
-        .then(convertSteps)
-        // Append flattened jobs and return flattened doc
-        .then((jobs) => {
-            doc.jobs = jobs;
+        .then(({ warnings, newJobs }) => {
+            // Clean through the job values
+            const cleanedJobs = cleanComplexEnvironment(newJobs);
+            // Convert steps into proper expanded output
+            const convertedJobs = convertSteps(cleanedJobs);
+
+            // Append flattened jobs and return flattened doc
+            doc.jobs = convertedJobs;
             delete doc.shared;
 
             const errors = checkAdditionalRules(doc);
@@ -429,6 +492,6 @@ module.exports = (parsedDoc, templateFactory) => {
                 throw new Error(errors.toString());
             }
 
-            return doc;
+            return { warnings, flattenedDoc: doc };
         });
 };

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -306,15 +306,10 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
                     return obj;
                 }, {});
 
-                if (!oldJob.order) {
-                    for (let i = 0; i < sharedConfig.steps.length; i += 1) {
-                        if (!oldSteps[Object.keys(sharedConfig.steps[i])]) {
-                            oldJob.steps.push(sharedConfig.steps[i]);
-                        }
+                for (let i = 0; i < sharedConfig.steps.length; i += 1) {
+                    if (!oldSteps[Object.keys(sharedConfig.steps[i])]) {
+                        oldJob.steps.push(sharedConfig.steps[i]);
                     }
-                // Merge shared steps with job steps if "order" keyword
-                } else {
-                    oldJob.steps = Hoek.applyToDefaults(sharedConfig.steps, oldJob.steps);
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "@hapi/hoek": "^9.0.4",
     "clone": "^2.1.2",
     "joi": "^17.1.1",
-    "js-yaml": "^3.13.0",
-    "keymbinatorial": "^1.1.5",
-    "screwdriver-data-schema": "^21.0.0",
-    "screwdriver-workflow-parser": "^3.0.0",
+    "js-yaml": "^3.14.1",
+    "keymbinatorial": "^1.1.6",
+    "screwdriver-data-schema": "^21.1.2",
     "screwdriver-notifications-email": "^2.1.0",
     "screwdriver-notifications-slack": "^3.1.0",
+    "screwdriver-workflow-parser": "^3.0.0",
     "shell-escape": "^0.2.0",
     "tinytim": "^0.1.1"
   }

--- a/test/data/basic-job-with-order-and-teardown.json
+++ b/test/data/basic-job-with-order-and-teardown.json
@@ -1,0 +1,61 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {
+                "screwdriver.cd/mergeSharedSteps": true
+            },
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "setup",
+                    "command": "npm audit fix"
+                },
+                {
+                    "name": "test",
+                    "command": "echo 'my job is overriding this step'"
+                },
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "teardown-always",
+                    "command": "echo 'done!'"
+                }
+            ],
+            "environment": {
+                "FOO": "from template",
+                "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-job-with-order-and-teardown.yaml
+++ b/test/data/basic-job-with-order-and-teardown.yaml
@@ -1,14 +1,23 @@
 shared:
   steps:
     - pretest: echo pre-test
+    - test: echo 'my job is overriding this step'
     - predummy: echo 'this step is not merged'
 jobs:
   main:
     annotations:
       screwdriver.cd/mergeSharedSteps: true
     template: mytemplate@1.2.3
+    order:
+      - setup
+      - test
+      - teardown-always
+      - install
     steps:
       - test: echo 'my job is overriding this step'
+      - setup: npm audit fix
+      - extra: echo 'not included'
+      - teardown-always: echo 'done!'
     requires:
       - ~pr
       - ~commit

--- a/test/data/basic-job-with-order.json
+++ b/test/data/basic-job-with-order.json
@@ -1,0 +1,57 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {
+                "screwdriver.cd/mergeSharedSteps": true
+            },
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "setup",
+                    "command": "npm audit fix"
+                },
+                {
+                    "name": "test",
+                    "command": "echo 'my job is overriding this step'"
+                },
+                {
+                    "name": "install",
+                    "command": "npm install"
+                }
+            ],
+            "environment": {
+                "FOO": "from template",
+                "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-job-with-order.yaml
+++ b/test/data/basic-job-with-order.yaml
@@ -13,7 +13,6 @@ jobs:
       - test
       - install
     steps:
-      - test: echo 'my job is overriding this step'
       - setup: npm audit fix
       - extra: echo 'not included'
     requires:

--- a/test/data/basic-job-with-order.yaml
+++ b/test/data/basic-job-with-order.yaml
@@ -1,14 +1,21 @@
 shared:
   steps:
     - pretest: echo pre-test
+    - test: echo 'my job is overriding this step'
     - predummy: echo 'this step is not merged'
 jobs:
   main:
     annotations:
       screwdriver.cd/mergeSharedSteps: true
     template: mytemplate@1.2.3
+    order:
+      - setup
+      - test
+      - install
     steps:
       - test: echo 'my job is overriding this step'
+      - setup: npm audit fix
+      - extra: echo 'not included'
     requires:
       - ~pr
       - ~commit

--- a/test/data/basic-job-with-warnings.json
+++ b/test/data/basic-job-with-warnings.json
@@ -1,0 +1,61 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {
+                "screwdriver.cd/mergeSharedSteps": true
+            },
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "setup",
+                    "command": "npm audit fix"
+                },
+                {
+                    "name": "test",
+                    "command": "echo 'my job is overriding this step'"
+                },
+                {
+                    "name": "install",
+                    "command": "npm install"
+                }
+            ],
+            "environment": {
+                "FOO": "from template",
+                "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" }
+        ]
+    },
+    "subscribe": {},
+    "warnMessages": [
+      "doesnotexist step definition not found; skipping",
+      "teardown-notdefined step definition not found; skipping"
+    ]
+}

--- a/test/data/basic-job-with-warnings.yaml
+++ b/test/data/basic-job-with-warnings.yaml
@@ -1,14 +1,23 @@
 shared:
   steps:
     - pretest: echo pre-test
+    - test: echo 'my job is overriding this step'
     - predummy: echo 'this step is not merged'
 jobs:
   main:
     annotations:
       screwdriver.cd/mergeSharedSteps: true
     template: mytemplate@1.2.3
+    order:
+      - setup
+      - test
+      - doesnotexist
+      - install
+      - teardown-notdefined
     steps:
       - test: echo 'my job is overriding this step'
+      - setup: npm audit fix
+      - extra: echo 'not included'
     requires:
       - ~pr
       - ~commit

--- a/test/data/pipeline-with-order-no-template.json
+++ b/test/data/pipeline-with-order-no-template.json
@@ -1,0 +1,54 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "test": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "image": "node:4",
+                "requires": ["~commit"],
+                "commands": [
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    }
+                ]
+            }
+        ],
+        "echo": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": ["~commit"],
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "echo-hello",
+                        "command": "echo hello"
+                    }
+                ]
+            }
+        ]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "test" },
+            { "name": "echo" }
+        ],
+        "edges": [
+            { "src": "~commit", "dest": "test" },
+            { "src": "~commit", "dest": "echo" }
+        ]
+    },
+    "subscribe": {},
+    "warnMessages": [
+      "\"order\" in echo job cannot be used without \"template\""
+    ]
+}

--- a/test/data/pipeline-with-order-no-template.yaml
+++ b/test/data/pipeline-with-order-no-template.yaml
@@ -1,0 +1,14 @@
+shared:
+    image: node:4
+jobs:
+    test:
+        steps:
+            - test: npm test
+        requires: ~commit
+    echo:
+        order: 
+            - echo-hello
+            - test
+        steps:
+            - echo-hello: echo hello
+        requires: ~commit

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -237,6 +237,13 @@ describe('config parser', () => {
                     JSON.parse(loadData('pipeline-with-freeze-windows.json')));
             }));
 
+        it('flattens with warnings with order and no template',
+            () => parser(loadData('pipeline-with-order-no-template.yaml'))
+                .then((data) => {
+                    assert.deepEqual(data,
+                        JSON.parse(loadData('pipeline-with-order-no-template.json')));
+                }));
+
         it('includes scm URLs', () => parser(loadData('pipeline-with-childPipelines.yaml'))
             .then((data) => {
                 assert.deepEqual(data,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -112,7 +112,7 @@ describe('config parser', () => {
         });
 
         describe('jobs', () => {
-            it('Do not return error if missing main job for new config',
+            it('does not return error if missing main job for new config',
                 () => parser(loadData('missing-main-job-with-requires.yaml'))
                     .then((data) => {
                         assert.notOk(data.errors);
@@ -292,7 +292,7 @@ describe('config parser', () => {
                     ));
             });
 
-            it('flattens templates with wrapped steps ',
+            it('flattens templates with wrapped steps',
                 () => parser(
                     loadData('basic-job-with-template-wrapped-steps.yaml'),
                     templateFactoryMock
@@ -300,7 +300,7 @@ describe('config parser', () => {
                     data, JSON.parse(loadData('basic-job-with-template-wrapped-steps.json'))
                 )));
 
-            it('flattens templates with job steps ',
+            it('flattens templates with job steps',
                 () => parser(
                     loadData('basic-job-with-template-override-steps.yaml'),
                     templateFactoryMock
@@ -308,12 +308,36 @@ describe('config parser', () => {
                     data, JSON.parse(loadData('basic-job-with-template-override-steps.json'))
                 )));
 
-            it('flattens templates with shared and job steps ',
+            it('flattens templates with shared and job steps',
                 () => parser(
                     loadData('basic-job-with-shared-and-template-override-steps.yaml'),
                     templateFactoryMock
                 ).then(data => assert.deepEqual(data, JSON.parse(loadData(
                     'basic-job-with-shared-and-template-override-steps.json'
+                )))));
+
+            it('flattens templates with order',
+                () => parser(
+                    loadData('basic-job-with-order.yaml'),
+                    templateFactoryMock
+                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                    'basic-job-with-order.json'
+                )))));
+
+            it('flattens templates with order and teardown',
+                () => parser(
+                    loadData('basic-job-with-order-and-teardown.yaml'),
+                    templateFactoryMock
+                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                    'basic-job-with-order-and-teardown.json'
+                )))));
+
+            it('flattens templates with warnings',
+                () => parser(
+                    loadData('basic-job-with-warnings.yaml'),
+                    templateFactoryMock
+                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                    'basic-job-with-warnings.json'
                 )))));
 
             it('template-teardown is merged into steps', () => {
@@ -422,7 +446,7 @@ describe('config parser', () => {
                     /"environment" can only have 100 environment/);
             }));
 
-        it('do not count SD_TEMPLATE variables for max environment variables',
+        it('does not count SD_TEMPLATE variables for max environment variables',
             () => parser(
                 loadData('environment-with-SD-variable.yaml'),
                 templateFactoryMock,


### PR DESCRIPTION
## Context

Would be nice if users could pick and choose from steps defined in their own screwdriver.yamls and template configs to determine which commands run.

## Objective

This PR adds support for `order` keyword and warnings.

Notes:
- `order` keyword can only be used when `template` is used.
- job-level step definitions will take priority over template step definitions
- job-level step definitions will take priority over shared-level step definitions. These combined will take priority over template step definitions when [screwdriver.cd/mergeSharedSteps: true](https://docs.screwdriver.cd/user-guide/templates#merging-with-shared-steps)
- implicit [wrap (pre/post)](https://docs.screwdriver.cd/user-guide/templates#wrap) function is not supported with `order` keyword.
- implicit [teardown-](https://docs.screwdriver.cd/user-guide/configuration/jobconfiguration#teardown) steps will still work

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
