### PR TITLE
feat(2339): Do not throw notifications validation error when flag set to false. BREAKING CHANGE: method expects object as param

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,16 +135,20 @@ function validateTemplateVersion(doc, templateFactory) {
 /**
  * Parse the configuration from a screwdriver.yaml
  * @method configParser
- * @param   {String}               yaml                Contents of screwdriver.yaml
- * @param   {TemplateFactory}      templateFactory     Template Factory to get templates
- * @param   {BuildClusterFactory}  buildClusterFactory Build cluster Factory to get build clusters
- * @param   {TriggerFactory}       triggerFactory      Trigger Factory to find external triggers
- * @param   {Number}               pipelineId          Id of the current pipeline
+ * @param   {Object}               config
+ * @param   {String}               config.yaml                Contents of screwdriver.yaml
+ * @param   {TemplateFactory}      config.templateFactory     Template Factory to get templates
+ * @param   {BuildClusterFactory}  config.buildClusterFactory Build cluster Factory to get build clusters
+ * @param   {TriggerFactory}       [config.triggerFactory]    Trigger Factory to find external triggers
+ * @param   {Number}               [config.pipelineId]        ID of the current pipeline
+ * @param   {Boolean}              [config.notificationsValidationErr]  Throw error when notifications validation fails (default true);
+ *                                                                      otherwise return warning
  * @returns {Promise}
  */
-module.exports = function configParser(
-    yaml, templateFactory, buildClusterFactory, triggerFactory, pipelineId
-) {
+module.exports = function configParser({
+    yaml, templateFactory, buildClusterFactory, triggerFactory, pipelineId,
+    notificationsValidationErr
+}) {
     let warnMessages = [];
 
     // Convert from YAML to JSON
@@ -158,11 +162,16 @@ module.exports = function configParser(
             return phaseFlatten(parsedDoc, templateFactory);
         })
         // Functionality validation
-        .then(flattenedDoc => phaseValidateFunctionality(flattenedDoc,
-            buildClusterFactory, triggerFactory, pipelineId))
+        .then(flattenedDoc => phaseValidateFunctionality({
+            flattenedDoc,
+            buildClusterFactory,
+            triggerFactory,
+            pipelineId,
+            notificationsValidationErr: notificationsValidationErr !== false
+        }))
         // Check warnMessages
-        .then((doc) => {
-            warnMessages = warnMessages.concat(validateReservedAnnotation(doc));
+        .then(({ doc, warnings }) => {
+            warnMessages = warnMessages.concat(warnings, validateReservedAnnotation(doc));
 
             return doc;
         })

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -24,11 +24,14 @@ const SDEnv = [
 /**
  * Ensure notifications plugin is valid
  * @method validateNotificationSetting
- * @param  {Object}               doc Document that went through flattening
- * @return {Array}                List of errors
+ * @param  {Object}   config
+ * @param  {Object}   config.doc                        Document that went through flattening
+ * @param  {Boolean}  config.notificationsValidationErr Throw error when notifications validation fails
+ * @return {Object}   Array of errors, array of warnings
  */
-function validateNotificationSetting(doc) {
+function validateNotificationSetting({ doc, notificationsValidationErr }) {
     const errors = [];
+    const warnings = [];
 
     Object.keys(doc.jobs).forEach((job) => {
         let error;
@@ -36,19 +39,25 @@ function validateNotificationSetting(doc) {
 
         if ('slack' in settings) {
             error = SlackValidation.validateConfig(settings);
-            if (error.error) {
+            if (error.error && notificationsValidationErr) {
                 errors.push(`${job} ${error.error.message}`);
+            } else if (error.error) {
+                warnings.push(`${job} ${error.error.message}; skipping`);
+                delete doc.jobs[job].settings.slack;
             }
         }
         if ('email' in settings) {
             error = EmailValidation.validateConfig(settings);
-            if (error.error) {
+            if (error.error && notificationsValidationErr) {
                 errors.push(`${job} ${error.error.message}`);
+            } else if (error.error) {
+                warnings.push(`${job} ${error.error.message}; skipping`);
+                delete doc.jobs[job].settings.email;
             }
         }
     });
 
-    return errors;
+    return { errMessages: errors, warnMessages: warnings };
 }
 
 /**
@@ -232,17 +241,22 @@ function validateWorkflowGraph(doc) {
  * jobs will execute as specified.  This is going to be mostly business logic like
  * too many environment variables.
  * @method
- * @param  {Object}              flattenedDoc           Document that went through flattening
- * @param  {BuildClusterFactory} buildClusterFactory    Build cluster Factory to get build clusters
- * @param  {TriggerFactory}      triggerFactory         Trigger Factory to find external triggers
- * @param  {Number}              pipelineId             Id of the current pipeline
- * @param  {Function}            callback               Function to call when done (err, doc)
+ * @param  {Object}              config
+ * @param  {Object}              config.flattenedDoc           Document that went through flattening
+ * @param  {BuildClusterFactory} config.buildClusterFactory    Build cluster Factory to get build clusters
+ * @param  {TriggerFactory}      [config.triggerFactory]       Trigger Factory to find external triggers
+ * @param  {Number}              [config.pipelineId]           ID of the current pipeline
+ * @param  {Boolean}             [config.notificationsValidationErr]  Throw error when notification validation fails (default true);
+ *                                                                    otherwise return warning
  * @param  {Promise}
  */
-module.exports = async (flattenedDoc, buildClusterFactory, triggerFactory, pipelineId) => (
+module.exports = async ({
+    flattenedDoc, buildClusterFactory, triggerFactory, pipelineId, notificationsValidationErr
+}) => (
     new Promise(async (resolve, reject) => {
         const doc = flattenedDoc;
         let errors = [];
+        let warnings = [];
 
         // Jobs
         errors = errors.concat(validateJobSchema(doc));
@@ -260,7 +274,13 @@ module.exports = async (flattenedDoc, buildClusterFactory, triggerFactory, pipel
 
         errors = errors.concat(validateWorkflowGraph(doc));
 
-        errors = errors.concat(validateNotificationSetting(doc));
+        const { warnMessages, errMessages } = validateNotificationSetting({
+            doc,
+            notificationsValidationErr
+        });
+
+        errors = errors.concat(errMessages);
+        warnings = warnings.concat(warnMessages);
 
         // Check if build cluster annotation is valid
         return validateBuildClusterAnnotation(doc, buildClusterFactory)
@@ -271,7 +291,7 @@ module.exports = async (flattenedDoc, buildClusterFactory, triggerFactory, pipel
                     return reject(new Error(errors.join('\n')));
                 }
 
-                return resolve(doc);
+                return resolve({ doc, warnings });
             });
     })
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-config-parser",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Node module for parsing screwdriver.yaml configurations",
   "main": "index.js",
   "scripts": {

--- a/test/data/bad-notification-slack-email-settings-warnings.json
+++ b/test/data/bad-notification-slack-email-settings-warnings.json
@@ -1,0 +1,53 @@
+{
+  "annotations": {},
+  "jobs": {
+      "main": [
+          {
+              "requires": [
+                  "~pr",
+                  "~commit"
+              ],
+              "image": "node:12",
+              "commands": [
+                  {
+                      "name": "install",
+                      "command": "npm install"
+                  }
+              ],
+              "annotations": {},
+              "secrets": [],
+              "environment": {},
+              "settings": {}
+          }
+      ]
+  },
+  "parameters": {},
+  "subscribe": {},
+  "warnMessages": [
+      "main \"slack.channnels\" is not allowed; skipping",
+      "main \"email.statuses[0]\" must be one of [ABORTED, CREATED, FAILURE, QUEUED, RUNNING, SUCCESS, BLOCKED, UNSTABLE, COLLAPSED, FROZEN]; skipping"
+  ],
+  "workflowGraph": {
+      "nodes": [
+          {
+              "name": "~pr"
+          },
+          {
+              "name": "~commit"
+          },
+          {
+              "name": "main"
+          }
+      ],
+      "edges": [
+          {
+              "src": "~pr",
+              "dest": "main"
+          },
+          {
+              "src": "~commit",
+              "dest": "main"
+          }
+      ]
+  }
+}

--- a/test/data/bad-notification-slack-email-settings.json
+++ b/test/data/bad-notification-slack-email-settings.json
@@ -7,7 +7,7 @@
               "commands": [
                   {
                       "name": "config-parse-error",
-                      "command": "echo 'Error: main \"slack.statuses[0]\" must be one of [ABORTED, CREATED, FAILURE, QUEUED, RUNNING, SUCCESS, BLOCKED, UNSTABLE, COLLAPSED, FROZEN]\nmain \"email.statuses[0]\" must be one of [ABORTED, CREATED, FAILURE, QUEUED, RUNNING, SUCCESS, BLOCKED, UNSTABLE, COLLAPSED, FROZEN]'; exit 1"
+                      "command": "echo 'Error: main \"slack.channnels\" is not allowed\nmain \"email.statuses[0]\" must be one of [ABORTED, CREATED, FAILURE, QUEUED, RUNNING, SUCCESS, BLOCKED, UNSTABLE, COLLAPSED, FROZEN]'; exit 1"
                   }
               ],
               "secrets": [],
@@ -46,6 +46,6 @@
       ]
   },
   "errors": [
-    "Error: main \"slack.statuses[0]\" must be one of [ABORTED, CREATED, FAILURE, QUEUED, RUNNING, SUCCESS, BLOCKED, UNSTABLE, COLLAPSED, FROZEN]\nmain \"email.statuses[0]\" must be one of [ABORTED, CREATED, FAILURE, QUEUED, RUNNING, SUCCESS, BLOCKED, UNSTABLE, COLLAPSED, FROZEN]"
+      "Error: main \"slack.channnels\" is not allowed\nmain \"email.statuses[0]\" must be one of [ABORTED, CREATED, FAILURE, QUEUED, RUNNING, SUCCESS, BLOCKED, UNSTABLE, COLLAPSED, FROZEN]"
   ]
 }

--- a/test/data/bad-notification-slack-email-settings.yaml
+++ b/test/data/bad-notification-slack-email-settings.yaml
@@ -11,7 +11,7 @@ jobs:
             channnels:
               - test
             statuses:
-              - UNDEFINED
+              - SUCCESS
           email:
             addresses:
               - bar@foo.com

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -246,11 +246,12 @@ describe('config parser', () => {
                         JSON.parse(loadData('pipeline-with-order-no-template.json')));
                 }));
 
-        it('includes scm URLs', () => parser({ yaml: loadData('pipeline-with-childPipelines.yaml') })
-            .then((data) => {
-                assert.deepEqual(data,
-                    JSON.parse(loadData('pipeline-with-childPipelines.json')));
-            }));
+        it('includes scm URLs',
+            () => parser({ yaml: loadData('pipeline-with-childPipelines.yaml') })
+                .then((data) => {
+                    assert.deepEqual(data,
+                        JSON.parse(loadData('pipeline-with-childPipelines.json')));
+                }));
 
         describe('templates', () => {
             const templateFactoryMock = {
@@ -331,26 +332,26 @@ describe('config parser', () => {
                 )))));
 
             it('flattens templates with order',
-                () => parser(
-                    loadData('basic-job-with-order.yaml'),
-                    templateFactoryMock
-                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                () => parser({
+                    yaml: loadData('basic-job-with-order.yaml'),
+                    templateFactory: templateFactoryMock
+                }).then(data => assert.deepEqual(data, JSON.parse(loadData(
                     'basic-job-with-order.json'
                 )))));
 
             it('flattens templates with order and teardown',
-                () => parser(
-                    loadData('basic-job-with-order-and-teardown.yaml'),
-                    templateFactoryMock
-                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                () => parser({
+                    yaml: loadData('basic-job-with-order-and-teardown.yaml'),
+                    templateFactory: templateFactoryMock
+                }).then(data => assert.deepEqual(data, JSON.parse(loadData(
                     'basic-job-with-order-and-teardown.json'
                 )))));
 
             it('flattens templates with warnings',
-                () => parser(
-                    loadData('basic-job-with-warnings.yaml'),
-                    templateFactoryMock
-                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                () => parser({
+                    yaml: loadData('basic-job-with-warnings.yaml'),
+                    templateFactory: templateFactoryMock
+                }).then(data => assert.deepEqual(data, JSON.parse(loadData(
                     'basic-job-with-warnings.json'
                 )))));
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,7 +24,7 @@ describe('config parser', () => {
         it('returns an error if yaml does not exist', () => {
             const YAMLMISSING = /screwdriver.yaml does not exist/;
 
-            return parser('')
+            return parser({ yaml: '' })
                 .then((data) => {
                     assert.deepEqual(data.workflowGraph, {
                         nodes: [
@@ -48,7 +48,7 @@ describe('config parser', () => {
                 });
         });
 
-        it('returns an error if unparsable yaml', () => parser('foo: :')
+        it('returns an error if unparsable yaml', () => parser({ yaml: 'foo: :' })
             .then((data) => {
                 assert.strictEqual(data.jobs.main[0].image, 'node:12');
                 assert.deepEqual(data.jobs.main[0].secrets, []);
@@ -59,7 +59,7 @@ describe('config parser', () => {
             }));
 
         it('returns an error if job has duplicate steps',
-            () => parser(loadData('basic-job-with-duplicate-steps.yaml'))
+            () => parser({ yaml: loadData('basic-job-with-duplicate-steps.yaml') })
                 .then((data) => {
                     assert.strictEqual(data.jobs.main[0].image, 'node:12');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
@@ -71,7 +71,7 @@ describe('config parser', () => {
                 }));
 
         it('does not return an error if job has no step names',
-            () => parser(loadData('basic-job-with-no-step-names.yaml')).then((data) => {
+            () => parser({ yaml: loadData('basic-job-with-no-step-names.yaml') }).then((data) => {
                 assert.strictEqual(data.jobs.main[0].image, 'node:6');
                 assert.deepEqual(data.jobs.main[0].secrets, []);
                 assert.deepEqual(data.jobs.main[0].environment, {});
@@ -79,7 +79,7 @@ describe('config parser', () => {
             }));
 
         it('returns an error if multiple documents without hint',
-            () => parser('foo: bar\n---\nfoo: baz')
+            () => parser({ yaml: 'foo: bar\n---\nfoo: baz' })
                 .then((data) => {
                     assert.strictEqual(data.jobs.main[0].image, 'node:12');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
@@ -90,21 +90,22 @@ describe('config parser', () => {
                     assert.match(data.errors[0], /YAMLException:.*ambigious/);
                 }));
 
-        it('picks the document with version hint', () => parser('jobs: {}\n---\nversion: 4')
-            .then((data) => {
-                assert.strictEqual(data.jobs.main[0].image, 'node:12');
-                assert.deepEqual(data.jobs.main[0].secrets, []);
-                assert.deepEqual(data.jobs.main[0].environment, {});
-                assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
-                assert.match(data.jobs.main[0].commands[0].command,
-                    /ValidationError:.*"jobs" is required/);
-                assert.match(data.errors[0], /ValidationError:.*"jobs" is required/);
-            }));
+        it('picks the document with version hint',
+            () => parser({ yaml: 'jobs: {}\n---\nversion: 4' })
+                .then((data) => {
+                    assert.strictEqual(data.jobs.main[0].image, 'node:12');
+                    assert.deepEqual(data.jobs.main[0].secrets, []);
+                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
+                    assert.match(data.jobs.main[0].commands[0].command,
+                        /ValidationError:.*"jobs" is required/);
+                    assert.match(data.errors[0], /ValidationError:.*"jobs" is required/);
+                }));
     });
 
     describe('structure validation', () => {
         describe('overall config', () => {
-            it('returns an error if missing jobs', () => parser('foo: bar')
+            it('returns an error if missing jobs', () => parser({ yaml: 'foo: bar' })
                 .then((data) => {
                     assert.match(data.jobs.main[0].commands[0].command, /"jobs" is required/);
                     assert.match(data.errors[0], /"jobs" is required/);
@@ -113,7 +114,7 @@ describe('config parser', () => {
 
         describe('jobs', () => {
             it('Do not return error if missing main job for new config',
-                () => parser(loadData('missing-main-job-with-requires.yaml'))
+                () => parser({ yaml: loadData('missing-main-job-with-requires.yaml') })
                     .then((data) => {
                         assert.notOk(data.errors);
                     }));
@@ -121,14 +122,14 @@ describe('config parser', () => {
 
         describe('steps', () => {
             it('returns an error if not bad named steps',
-                () => parser(loadData('bad-step-name.yaml'))
+                () => parser({ yaml: loadData('bad-step-name.yaml') })
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
                             /.foo bar" only supports the following characters A-Z,a-z,0-9,-,_';/);
                     }));
 
             it('returns an error if teardown step is not at the end',
-                () => parser(loadData('bad-step-teardown.yaml'))
+                () => parser({ yaml: loadData('bad-step-teardown.yaml') })
                     .then((data) => {
                         assert.match(data.errors[0],
                             /User teardown steps need to be at the end/);
@@ -137,7 +138,7 @@ describe('config parser', () => {
 
         describe('environment', () => {
             it('returns an error if bad environment name',
-                () => parser(loadData('bad-environment-name.yaml'))
+                () => parser({ yaml: loadData('bad-environment-name.yaml') })
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
                             /"jobs.main.environment.foo bar" only supports uppercase letters,/);
@@ -145,16 +146,17 @@ describe('config parser', () => {
         });
 
         describe('matrix', () => {
-            it('returns an error if bad matrix name', () => parser(loadData('bad-matrix-name.yaml'))
-                .then((data) => {
-                    assert.match(data.jobs.main[0].commands[0].command,
-                        /"jobs.main.matrix.foo bar" only supports uppercase letters,/);
-                }));
+            it('returns an error if bad matrix name',
+                () => parser({ yaml: loadData('bad-matrix-name.yaml') })
+                    .then((data) => {
+                        assert.match(data.jobs.main[0].commands[0].command,
+                            /"jobs.main.matrix.foo bar" only supports uppercase letters,/);
+                    }));
         });
 
         describe('childPipelines', () => {
             it('returns an error if bad childPipelines',
-                () => parser(loadData('bad-external-scm.yaml'))
+                () => parser({ yaml: loadData('bad-external-scm.yaml') })
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
                             /"fakeScmUrl" fails to match the required pattern:/);
@@ -163,7 +165,7 @@ describe('config parser', () => {
 
         describe('subscribe', () => {
             it('fetches subscribe from the config and adds to parsed doc',
-                () => parser(loadData('pipeline-with-subscribed-scms.yaml'))
+                () => parser({ yaml: loadData('pipeline-with-subscribed-scms.yaml') })
                     .then((data) => {
                         assert.deepEqual(data,
                             JSON.parse(loadData('pipeline-with-subscribed-scms.json')));
@@ -173,75 +175,76 @@ describe('config parser', () => {
 
     describe('flatten', () => {
         it('replaces steps, matrix, image, but merges environment',
-            () => parser(loadData('basic-shared-project.yaml'))
+            () => parser({ yaml: loadData('basic-shared-project.yaml') })
                 .then((data) => {
                     assert.deepEqual(data, JSON.parse(loadData('basic-shared-project.json')));
                 }));
 
         it('replaces settings if empty object',
-            () => parser(loadData('basic-shared-project-empty-settings.yaml'))
+            () => parser({ yaml: loadData('basic-shared-project-empty-settings.yaml') })
                 .then((data) => {
-                    assert.deepEqual(data, JSON.parse(
-                        loadData('basic-shared-project-empty-settings.json')
-                    ));
+                    assert.deepEqual(data,
+                        JSON.parse(loadData('basic-shared-project-empty-settings.json')));
                 }));
 
-        it('flattens complex environments', () => parser(loadData('complex-environment.yaml'))
-            .then((data) => {
-                assert.deepEqual(data, JSON.parse(loadData('complex-environment.json')));
-            }));
+        it('flattens complex environments',
+            () => parser({ yaml: loadData('complex-environment.yaml') })
+                .then((data) => {
+                    assert.deepEqual(data,
+                        JSON.parse(loadData('complex-environment.json')));
+                }));
 
         it('flattens shared annotations to each job',
-            () => parser(loadData('shared-annotations.yaml'))
+            () => parser({ yaml: loadData('shared-annotations.yaml') })
                 .then((data) => {
                     assert.deepEqual(data, JSON.parse(loadData('shared-annotations.json')));
                 }));
 
         it('includes pipeline- and job-level annotations',
-            () => parser(loadData('pipeline-and-job-annotations.yaml'))
+            () => parser({ yaml: loadData('pipeline-and-job-annotations.yaml') })
                 .then((data) => {
                     assert.deepEqual(data,
                         JSON.parse(loadData('pipeline-and-job-annotations.json')));
                 }));
 
         it('job-level annotations override shared-level annotations',
-            () => parser(loadData('shared-job-annotations.yaml'))
+            () => parser({ yaml: loadData('shared-job-annotations.yaml') })
                 .then((data) => {
                     assert.deepEqual(data,
                         JSON.parse(loadData('shared-job-annotations.json')));
                 }));
 
         it('job-level sourcePaths override shared-level sourcePaths',
-            () => parser(loadData('pipeline-with-sourcePaths.yaml'))
+            () => parser({ yaml: loadData('pipeline-with-sourcePaths.yaml') })
                 .then((data) => {
-                    assert.deepEqual(data,
-                        JSON.parse(loadData('pipeline-with-sourcePaths.json')));
+                    assert.deepEqual(data, JSON.parse(loadData('pipeline-with-sourcePaths.json')));
                 }));
 
         it('flattens when sourcePaths are string',
-            () => parser(loadData('pipeline-with-sourcePaths-string.yaml'))
+            () => parser({ yaml: loadData('pipeline-with-sourcePaths-string.yaml') })
                 .then((data) => {
                     assert.deepEqual(data,
                         JSON.parse(loadData('pipeline-with-sourcePaths-string.json')));
                 }));
 
-        it('flattens blockedBy', () => parser(loadData('pipeline-with-blocked-by.yaml'))
+        it('flattens blockedBy', () => parser({ yaml: loadData('pipeline-with-blocked-by.yaml') })
             .then((data) => {
-                assert.deepEqual(data,
-                    JSON.parse(loadData('pipeline-with-blocked-by.json')));
+                assert.deepEqual(data, JSON.parse(loadData('pipeline-with-blocked-by.json')));
             }));
 
-        it('flattens freezeWindows', () => parser(loadData('pipeline-with-freeze-windows.yaml'))
-            .then((data) => {
-                assert.deepEqual(data,
-                    JSON.parse(loadData('pipeline-with-freeze-windows.json')));
-            }));
+        it('flattens freezeWindows',
+            () => parser({ yaml: loadData('pipeline-with-freeze-windows.yaml') })
+                .then((data) => {
+                    assert.deepEqual(data,
+                        JSON.parse(loadData('pipeline-with-freeze-windows.json')));
+                }));
 
-        it('includes scm URLs', () => parser(loadData('pipeline-with-childPipelines.yaml'))
-            .then((data) => {
-                assert.deepEqual(data,
-                    JSON.parse(loadData('pipeline-with-childPipelines.json')));
-            }));
+        it('includes scm URLs',
+            () => parser({ yaml: loadData('pipeline-with-childPipelines.yaml') })
+                .then((data) => {
+                    assert.deepEqual(data,
+                        JSON.parse(loadData('pipeline-with-childPipelines.json')));
+                }));
 
         describe('templates', () => {
             const templateFactoryMock = {
@@ -276,7 +279,10 @@ describe('config parser', () => {
             });
 
             it('flattens templates successfully',
-                () => parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
+                () => parser({
+                    yaml: loadData('basic-job-with-template.yaml'),
+                    templateFactory: templateFactoryMock
+                })
                     .then(data => assert.deepEqual(
                         data, JSON.parse(loadData('basic-job-with-template.json'))
                     )));
@@ -285,34 +291,36 @@ describe('config parser', () => {
                 templateFactoryMock.getTemplate.withArgs('yourtemplate@2')
                     .resolves(defaultTemplate);
 
-                return parser(loadData('basic-job-with-template-with-namespace.yaml'),
-                    templateFactoryMock)
+                return parser({
+                    yaml: loadData('basic-job-with-template-with-namespace.yaml'),
+                    templateFactory: templateFactoryMock
+                })
                     .then(data => assert.deepEqual(
                         data, JSON.parse(loadData('basic-job-with-template-with-namespace.json'))
                     ));
             });
 
             it('flattens templates with wrapped steps ',
-                () => parser(
-                    loadData('basic-job-with-template-wrapped-steps.yaml'),
-                    templateFactoryMock
-                ).then(data => assert.deepEqual(
+                () => parser({
+                    yaml: loadData('basic-job-with-template-wrapped-steps.yaml'),
+                    templateFactory: templateFactoryMock
+                }).then(data => assert.deepEqual(
                     data, JSON.parse(loadData('basic-job-with-template-wrapped-steps.json'))
                 )));
 
             it('flattens templates with job steps ',
-                () => parser(
-                    loadData('basic-job-with-template-override-steps.yaml'),
-                    templateFactoryMock
-                ).then(data => assert.deepEqual(
+                () => parser({
+                    yaml: loadData('basic-job-with-template-override-steps.yaml'),
+                    templateFactory: templateFactoryMock
+                }).then(data => assert.deepEqual(
                     data, JSON.parse(loadData('basic-job-with-template-override-steps.json'))
                 )));
 
             it('flattens templates with shared and job steps ',
-                () => parser(
-                    loadData('basic-job-with-shared-and-template-override-steps.yaml'),
-                    templateFactoryMock
-                ).then(data => assert.deepEqual(data, JSON.parse(loadData(
+                () => parser({
+                    yaml: loadData('basic-job-with-shared-and-template-override-steps.yaml'),
+                    templateFactory: templateFactoryMock
+                }).then(data => assert.deepEqual(data, JSON.parse(loadData(
                     'basic-job-with-shared-and-template-override-steps.json'
                 )))));
 
@@ -321,9 +329,10 @@ describe('config parser', () => {
                     JSON.parse(loadData('template-with-teardown.json'))
                 );
 
-                return parser(
-                    loadData('basic-job-with-template-override-steps.yaml'), templateFactoryMock
-                )
+                return parser({
+                    yaml: loadData('basic-job-with-template-override-steps.yaml'),
+                    templateFactory: templateFactoryMock
+                })
                     .then(data => assert.deepEqual(data, JSON.parse(loadData(
                         'basic-job-with-template-override-steps-template-teardown.json'
                     ))));
@@ -334,19 +343,20 @@ describe('config parser', () => {
                     JSON.parse(loadData('template-with-teardown.json'))
                 );
 
-                return parser(loadData(
-                    'basic-job-with-template-override-steps-teardown.yaml'
-                ), templateFactoryMock)
+                return parser({
+                    yaml: loadData('basic-job-with-template-override-steps-teardown.yaml'),
+                    templateFactory: templateFactoryMock
+                })
                     .then(data => assert.deepEqual(data, JSON.parse(loadData(
                         'basic-job-with-template-override-steps-teardown.json'
                     ))));
             });
 
             it('returns errors if flattens templates with job has duplicate steps',
-                () => parser(
-                    loadData('basic-job-with-template-duplicate-steps.yaml'),
-                    templateFactoryMock
-                ).then((data) => {
+                () => parser({
+                    yaml: loadData('basic-job-with-template-duplicate-steps.yaml'),
+                    templateFactory: templateFactoryMock
+                }).then((data) => {
                     assert.strictEqual(data.jobs.main[0].commands[0].name,
                         'config-parse-error');
                     assert.match(data.jobs.main[0].commands[0].command,
@@ -356,7 +366,10 @@ describe('config parser', () => {
                 }));
 
             it('flattens templates with images',
-                () => parser(loadData('basic-job-with-images.yaml'), templateFactoryMock)
+                () => parser({
+                    yaml: loadData('basic-job-with-images.yaml'),
+                    templateFactory: templateFactoryMock
+                })
                     .then(data => assert.deepEqual(
                         data, JSON.parse(loadData('basic-job-with-images.json'))
                     )));
@@ -364,7 +377,10 @@ describe('config parser', () => {
             it('returns error if template does not exist', () => {
                 templateFactoryMock.getTemplate.withArgs('mytemplate@1.2.3').resolves(null);
 
-                return parser(loadData('basic-job-with-template.yaml'), templateFactoryMock)
+                return parser({
+                    yaml: loadData('basic-job-with-template.yaml'),
+                    templateFactory: templateFactoryMock
+                })
                     .then((data) => {
                         assert.match(data.jobs.main[0].commands[0].command,
                             /Template mytemplate@1.2.3 does not exist/);
@@ -399,246 +415,260 @@ describe('config parser', () => {
         };
 
         it('returns an error if not enough steps',
-            () => parser(
-                loadData('not-enough-commands.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('not-enough-commands.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
                     /"jobs.main.steps" must contain at least 1 items/);
             }));
 
         it('returns an error if too many environment variables',
-            () => parser(
-                loadData('too-many-environment.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('too-many-environment.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
                     /"environment" can only have 100 environment/);
             }));
 
         it('do not count SD_TEMPLATE variables for max environment variables',
-            () => parser(
-                loadData('environment-with-SD-variable.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('environment-with-SD-variable.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.notMatch(data.jobs.main[0].commands[0].command,
                     /"environment" can only have 100 environment/);
             }));
 
         it('returns an error if too many environment + matrix variables',
-            () => parser(
-                loadData('too-many-matrix.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('too-many-matrix.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
                     /"environment" and "matrix" can only have a combined/);
             }));
 
         it('returns an error if matrix is too big',
-            () => parser(
-                loadData('too-big-matrix.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('too-big-matrix.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
                     /Job "main": "matrix" cannot contain >25 perm/);
             }));
 
         it('returns an error if using restricted step names',
-            () => parser(
-                loadData('restricted-step-name.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('restricted-step-name.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
                     /Job "main": Step "sd-setup": cannot use a restricted prefix "sd-"/);
             }));
 
         it('returns an error if using restricted job names',
-            () => parser(
-                loadData('restricted-job-name.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('restricted-job-name.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
                     /Job "pr-15": cannot use a restricted prefix "pr-"/);
             }));
 
         it('reads annotations on the pipeline-level',
-            () => parser(
-                loadData('pipeline-annotations.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('pipeline-annotations.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(loadData('pipeline-annotations.json')));
             }));
 
         it('reads cache on the pipeline-level',
-            () => parser(
-                loadData('pipeline-cache.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('pipeline-cache.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(loadData('pipeline-cache.json')));
             }));
 
         it('returns an error if job specified in cache config does not exist',
-            () => parser(
-                loadData('pipeline-cache-nonexist-job.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('pipeline-cache-nonexist-job.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('pipeline-cache-nonexist-job.json')
                 ));
             }));
 
         it('reads cache false on the job',
-            () => parser(
-                loadData('pipeline-cache-false-job.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('pipeline-cache-false-job.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('pipeline-cache-false-job.json')
                 ));
             }));
 
         it('ignore cache false on the job when the cache config does not exist',
-            () => parser(
-                loadData('pipeline-cache-false-nonexist-job.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('pipeline-cache-false-nonexist-job.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('pipeline-cache-false-nonexist-job.json')
                 ));
             }));
 
         it('validates build cluster',
-            () => parser(
-                loadData('build-cluster.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('build-cluster.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(loadData('build-cluster.json')));
             }));
 
         it('returns an error if build cluster does not exist',
-            () => parser(
-                loadData('bad-build-cluster.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('bad-build-cluster.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('bad-build-cluster.json')
                 ));
             }));
 
         it('allows a description key',
-            () => parser(
-                loadData('basic-job-with-description.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('basic-job-with-description.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.isDefined(data.jobs.main[0].description);
                 assert.equal(data.jobs.main[0].description,
                     'This is a description');
             }));
 
         it('returns an error if workflowGraph has cycle',
-            () => parser(
-                loadData('pipeline-with-requires-cycle.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('pipeline-with-requires-cycle.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.match(data.jobs.main[0].commands[0].command,
                     /Jobs: should not have circular dependency in jobs/);
             }));
 
         it('returns an error if wrong notification slack setting',
-            () => parser(
-                loadData('bad-notification-slack-settings.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('bad-notification-slack-settings.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('bad-notification-slack-settings.json')
                 ));
             }));
 
         it('returns an error if wrong notification email setting',
-            () => parser(
-                loadData('bad-notification-email-settings.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('bad-notification-email-settings.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('bad-notification-email-settings.json')
                 ));
             }));
 
+        it('returns a warning if wrong notification slack and email setting with flag set to false',
+            () => parser({
+                yaml: loadData('bad-notification-slack-email-settings.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
+                triggerFactory,
+                pipelineId,
+                notificationsValidationErr: false
+            }).then((data) => {
+                assert.deepEqual(data, JSON.parse(
+                    loadData('bad-notification-slack-email-settings-warnings.json')
+                ));
+            }));
+
         it('returns an error if wrong notification slack and email setting',
-            () => parser(
-                loadData('bad-notification-slack-email-settings.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('bad-notification-slack-email-settings.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('bad-notification-slack-email-settings.json')
                 ));
             }));
 
         it('returns an error if wrong notification shared setting',
-            () => parser(
-                loadData('bad-notification-shared-settings.yaml'),
-                templateFactoryMock,
-                buildClusterFactoryMock,
+            () => parser({
+                yaml: loadData('bad-notification-shared-settings.yaml'),
+                templateFactory: templateFactoryMock,
+                buildClusterFactory: buildClusterFactoryMock,
                 triggerFactory,
                 pipelineId
-            ).then((data) => {
+            }).then((data) => {
                 assert.deepEqual(data, JSON.parse(
                     loadData('bad-notification-shared-settings.json')
                 ));
@@ -659,7 +689,7 @@ describe('config parser', () => {
         });
 
         it('warning it is not pipeline-level annotation',
-            () => parser(loadData('warn-pipeline-level-annotation.yaml'))
+            () => parser({ yaml: loadData('warn-pipeline-level-annotation.yaml') })
                 .then((data) => {
                     /* eslint-disable max-len */
                     assert.match(data.warnMessages[0],
@@ -667,7 +697,7 @@ describe('config parser', () => {
                     /* eslint-enable max-len */
                 }));
         it('warning it is not job-level annotation',
-            () => parser(loadData('warn-job-level-annotation.yaml'))
+            () => parser({ yaml: loadData('warn-job-level-annotation.yaml') })
                 .then((data) => {
                     /* eslint-disable max-len */
                     assert.match(data.warnMessages[0],
@@ -677,7 +707,10 @@ describe('config parser', () => {
                     /* eslint-enable max-len */
                 }));
         it('warning template version is not specify in shared settings',
-            () => parser(loadData('warn-shared-template-version.yaml'), templateFactoryMock)
+            () => parser({
+                yaml: loadData('warn-shared-template-version.yaml'),
+                templateFactory: templateFactoryMock
+            })
                 .then((data) => {
                     /* eslint-disable max-len */
                     assert.match(data.warnMessages[0],
@@ -685,7 +718,10 @@ describe('config parser', () => {
                     /* eslint-enable max-len */
                 }));
         it('warning template version is not specify in job settings',
-            () => parser(loadData('warn-job-template-version.yaml'), templateFactoryMock)
+            () => parser({
+                yaml: loadData('warn-job-template-version.yaml'),
+                templateFactory: templateFactoryMock
+            })
                 .then((data) => {
                     /* eslint-disable max-len */
                     assert.match(data.warnMessages[0],
@@ -698,19 +734,19 @@ describe('config parser', () => {
 
     describe('permutation', () => {
         it('generates complex permutations and expands image',
-            () => parser(loadData('node-module.yaml'))
+            () => parser({ yaml: loadData('node-module.yaml') })
                 .then((data) => {
                     assert.deepEqual(data, JSON.parse(loadData('node-module.json')));
                 }));
 
         it('generates correct jobs',
-            () => parser(loadData('pipeline-with-requires.yaml'))
+            () => parser({ yaml: loadData('pipeline-with-requires.yaml') })
                 .then((data) => {
                     assert.deepEqual(data, JSON.parse(loadData('pipeline-with-requires.json')));
                 }));
 
         it('generates correct nodes with external pipeline',
-            () => parser(loadData('pipeline-with-requires-external.yaml'))
+            () => parser({ yaml: loadData('pipeline-with-requires-external.yaml') })
                 .then((data) => {
                     assert.deepEqual(data,
                         JSON.parse(loadData('pipeline-with-requires-external.json')));


### PR DESCRIPTION
## Context

Cluster admins might not deem invalid notifications settings as a reason to fail a build. 

## Objective

This PR takes in a flag to determine if an error or warning should be shown when notifications settings are invalid.
- The flag will default to true, which results in error.
- If the flag is set to false, a warning will be returned, the invalid setting will be deleted, and the build will run as usual.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2339

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
