### PR TITLE
feat(2331): Support locked template steps [3]

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -451,11 +451,13 @@ function convertSteps(jobs) {
         newJobs[jobName].commands = steps.map((step, index) => {
             let name;
             let command;
+            let locked;
 
             switch (typeof step) {
             case 'object':
                 name = Object.keys(step).pop();
                 command = step[name].command || step[name];
+                ({ locked } = step[name]);
                 break;
 
             case 'string':
@@ -464,6 +466,10 @@ function convertSteps(jobs) {
                 break;
 
             default:
+            }
+
+            if (locked) {
+                return { name, command, locked };
             }
 
             return { name, command };

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -112,38 +112,74 @@ function merge(newJob, oldJob, fromTemplate) {
     newJob.sourcePaths = [...new Set([...newsourcePaths, ...oldsourcePaths])];
 
     let warnings = [];
+    let newSteps = [];
+    let oldSteps = [];
+    const mergedSteps = [];
+    const lockedStepNames = [];
+    const teardownSteps = [];
+
+    if (Hoek.reach(newJob, 'steps')) {
+        newSteps = newJob.steps.reduce((obj, item) => {
+            const key = Object.keys(item)[0];
+            const substepKeys = typeof item[key] === 'object' ? Object.keys(item[key]) : undefined;
+
+            // Compress step if only has command key
+            if (substepKeys && substepKeys.length === 1) {
+                obj[key] = item[key].command;
+            } else {
+                if (substepKeys && substepKeys.includes('locked')) {
+                    lockedStepNames.push(key);
+                }
+                obj[key] = item[key];
+            }
+
+            return obj;
+        }, {});
+    }
+    if (Hoek.reach(oldJob, 'steps')) {
+        // convert steps from oldJob from array to object for faster lookup
+        oldSteps = oldJob.steps.reduce((obj, item) => {
+            const key = Object.keys(item)[0];
+            const substepKeys = typeof item[key] === 'object' ? Object.keys(item[key]) : undefined;
+
+            if (!oldJob.order && key.startsWith('teardown-')) {
+                teardownSteps.push(key);
+            }
+
+            // Compress step if only has command key
+            if (substepKeys && substepKeys.length === 1) {
+                obj[key] = item[key].command;
+            } else {
+                obj[key] = item[key];
+            }
+
+            return obj;
+        }, {});
+    }
 
     // Use "order" to get steps, ignore all other steps;
     // current template has precedence over external template
     if (fromTemplate && oldJob.order) {
         let stepName;
-        const mergedSteps = [];
-        const teardownSteps = [];
 
-        // Convert steps from array to object for faster lookup
-        const oldSteps = oldJob.steps.reduce((obj, item) => {
-            const key = Object.keys(item)[0];
+        // Order must contain locked steps
+        const orderContainsLockedSteps = lockedStepNames.every(v => oldJob.order.includes(v));
 
-            obj[key] = item[key];
-
-            return obj;
-        }, {});
-        const newSteps = newJob.steps.reduce((obj, item) => {
-            const key = Object.keys(item)[0];
-
-            obj[key] = item[key];
-
-            return obj;
-        }, {});
+        if (!orderContainsLockedSteps) {
+            // eslint-disable-next-line max-len
+            throw new Error(`Order must contain template ${oldJob.template} locked steps: ${lockedStepNames}`);
+        }
 
         for (let i = 0; i < oldJob.order.length; i += 1) {
             let step;
 
             stepName = oldJob.order[i];
 
-            if (oldSteps && oldSteps[stepName]) {
+            const stepLocked = Hoek.reach(newSteps[stepName], 'locked');
+
+            if (!stepLocked && Hoek.reach(oldSteps, stepName)) {
                 step = { [stepName]: oldSteps[stepName] };
-            } else if (newSteps && newSteps[stepName]) {
+            } else if (stepLocked || Hoek.reach(newSteps, stepName)) {
                 step = { [stepName]: newSteps[stepName] };
             } else {
                 warnings = warnings.concat(`${stepName} step definition not found; skipping`);
@@ -164,21 +200,6 @@ function merge(newJob, oldJob, fromTemplate) {
         let stepName;
         let preStepName;
         let postStepName;
-        const mergedSteps = [];
-        const teardownSteps = [];
-
-        // convert steps from oldJob from array to object for faster lookup
-        const oldSteps = oldJob.steps.reduce((obj, item) => {
-            const key = Object.keys(item)[0];
-
-            if (key.startsWith('teardown-')) {
-                teardownSteps.push(key);
-            }
-
-            obj[key] = item[key];
-
-            return obj;
-        }, {});
 
         for (let i = 0; i < newJob.steps.length; i += 1) {
             [stepName] = Object.keys(newJob.steps[i]);
@@ -190,8 +211,8 @@ function merge(newJob, oldJob, fromTemplate) {
                 mergedSteps.push({ [preStepName]: oldSteps[preStepName] });
             }
 
-            // if user doesn't define the same step, add it
-            if (!oldSteps[stepName]) {
+            // If template step is locked or user doesn't define the same step, add it
+            if (Hoek.reach(newJob.steps[i][stepName], 'locked') || !oldSteps[stepName]) {
                 mergedSteps.push(newJob.steps[i]);
             } else if (!stepName.startsWith('teardown-')) {
                 // if user defines the same step, only add if it's not teardown
@@ -410,10 +431,11 @@ function cleanComplexEnvironment(jobs) {
  *
  * This is because the user can provide either:
  *  - "command to execute"
- *  - { name: command }
+ *  - { "name": "command" }
+ *  - { "name": { "command": "somecommand", "otherkey": "value" }}
  *
  * The launcher expects it in a consistent format:
- *  - { name: "name", command: "command" }
+ *  - { "name": "name", "command": "command", "otherkey": "value" }
  * @method convertSteps
  * @param  {Object}       jobs   Object with all the jobs
  * @return {Object}              New object with jobs after up-converting
@@ -433,7 +455,7 @@ function convertSteps(jobs) {
             switch (typeof step) {
             case 'object':
                 name = Object.keys(step).pop();
-                command = step[name];
+                command = step[name].command || step[name];
                 break;
 
             case 'string':

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "joi": "^17.1.1",
     "js-yaml": "^3.14.1",
     "keymbinatorial": "^1.1.6",
-    "screwdriver-data-schema": "^21.1.2",
+    "screwdriver-data-schema": "^21.2.0",
     "screwdriver-notifications-email": "^2.1.0",
     "screwdriver-notifications-slack": "^3.1.0",
     "screwdriver-workflow-parser": "^3.0.0",

--- a/test/data/basic-job-with-template-locked-steps.json
+++ b/test/data/basic-job-with-template-locked-steps.json
@@ -16,11 +16,13 @@
                 },
                 {
                     "name": "init",
-                    "command": "npm preinstall"
+                    "command": "npm preinstall",
+                    "locked": true
                 },
                 {
                     "name": "install",
-                    "command": "npm install"
+                    "command": "npm install",
+                    "locked": true
                 }
             ],
             "environment": {

--- a/test/data/basic-job-with-template-locked-steps.json
+++ b/test/data/basic-job-with-template-locked-steps.json
@@ -1,0 +1,53 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "image": "node:8",
+            "commands": [
+                {
+                    "name": "setup",
+                    "command": "npm audit fix"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                },
+                {
+                    "name": "init",
+                    "command": "npm preinstall"
+                },
+                {
+                    "name": "install",
+                    "command": "npm install"
+                }
+            ],
+            "environment": {
+                "SD_TEMPLATE_FULLNAME": "lockedSteps",
+                "SD_TEMPLATE_NAME": "lockedSteps",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [],
+            "settings": {},
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-job-with-template-locked-steps.yaml
+++ b/test/data/basic-job-with-template-locked-steps.yaml
@@ -1,0 +1,14 @@
+jobs:
+  main:
+    template: lockedSteps@1
+    order:
+      - setup
+      - test
+      - init
+      - install
+    steps:
+      - setup: npm audit fix
+      - extra: echo 'not included'
+    requires:
+      - ~pr
+      - ~commit

--- a/test/data/basic-job-with-template-missing-locked-steps.json
+++ b/test/data/basic-job-with-template-missing-locked-steps.json
@@ -1,0 +1,53 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "image": "node:8",
+            "commands": [
+                {
+                    "name": "setup",
+                    "command": "npm audit fix"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                },
+                {
+                    "name": "init",
+                    "command": "npm preinstall"
+                },
+                {
+                    "name": "install",
+                    "command": "npm install"
+                }
+            ],
+            "environment": {
+                "SD_TEMPLATE_FULLNAME": "lockedSteps",
+                "SD_TEMPLATE_NAME": "lockedSteps",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [],
+            "settings": {},
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-job-with-template-missing-locked-steps.yaml
+++ b/test/data/basic-job-with-template-missing-locked-steps.yaml
@@ -1,0 +1,14 @@
+jobs:
+  main:
+    template: lockedSteps@1
+    order:
+      - setup
+      - test
+      - init
+      - extra
+    steps:
+      - setup: npm audit fix
+      - extra: echo 'this should fail'
+    requires:
+      - ~pr
+      - ~commit

--- a/test/data/steps.json
+++ b/test/data/steps.json
@@ -1,0 +1,44 @@
+{
+  "annotations": {},
+  "jobs": {
+    "main": [
+      {
+        "annotations": {},
+        "commands": [
+          {
+            "command": "echo First",
+            "name": "first"
+          },
+          {
+            "command": "echo Second",
+            "name": "step-2"
+          },
+          {
+            "command": "echo Last",
+            "name": "last"
+          }
+        ],
+        "environment": {},
+        "image": "node:8",
+        "secrets": [],
+        "settings": {}
+      }
+    ]
+  },
+  "parameters": {},
+  "subscribe": {},
+  "workflowGraph": {
+    "edges": [],
+    "nodes": [
+      {
+        "name": "~pr"
+      },
+      {
+        "name": "~commit"
+      },
+      {
+        "name": "main"
+      }
+    ]
+  }
+}

--- a/test/data/steps.yaml
+++ b/test/data/steps.yaml
@@ -1,0 +1,8 @@
+jobs:
+    main:
+        image: node:8
+        steps:
+            - first: echo First
+            - echo Second
+            - last:
+                  command: echo Last

--- a/test/data/templateWithLockedSteps.json
+++ b/test/data/templateWithLockedSteps.json
@@ -1,0 +1,21 @@
+{
+    "id": 7754,
+    "name": "lockedSteps",
+    "version": "1.2.3",
+    "config": {
+        "image": "node:8",
+        "steps": [
+            { "init": {
+                    "command": "npm preinstall",
+                    "locked": true
+                }
+            },
+            { "install": {
+                    "command": "npm install",
+                    "locked": true
+                } },
+            { "test": "npm test" },
+            { "publish": "npm publish" }
+        ]
+    }
+}


### PR DESCRIPTION
## Context

It would be nice if template owners could specify steps that are `locked` or cannot be overwritten. They would be required to be listed even if `order` is used.

## Objective

This PR supports template locked steps. Also converts steps with subobject to correct format.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2331

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
