### PR TITLE
fix duplicate step error

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -13,14 +13,14 @@ function checkAdditionalRules(doc) {
     const errors = [];
 
     Object.keys(doc.jobs).forEach((job) => {
-        const { steps } = doc.jobs[job];
+        const { commands } = doc.jobs[job];
         const stepList = [];
 
-        if (steps) {
-            for (let i = 0; i < steps.length; i += 1) {
-                const stepName = Object.keys(steps[i])[0];
+        if (commands) {
+            for (let i = 0; i < commands.length; i += 1) {
+                const stepName = Object.values(commands[i])[0];
 
-                if ((typeof (steps[i]) === 'object') && (stepList.includes(stepName))) {
+                if ((typeof (commands[i]) === 'object') && (stepList.includes(stepName))) {
                     errors.push(`Job ${job} has duplicate step: ${stepName}`);
                 }
 


### PR DESCRIPTION
## Context
Multiple steps with the same name can be in a single job at some cases.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Originally, `checkAdditionalRules` only checked the steps that had been already objects before they were converted in `convertSteps`. We should also check the steps that were originally strings. We change `checkAdditionalRules` to check what have been converted in `convertSteps` and are now all objects.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2403
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
