### PR TITLE
fix(2478): Description missing for jobs using templates

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -76,6 +76,10 @@ function merge(newJob, oldJob, fromTemplate) {
     Object.assign(newJob.settings, oldJob.settings || {});
     newJob.image = oldJob.image || newJob.image;
 
+    if (oldJob.description) {
+        newJob.description = oldJob.description;
+    }
+
     if (oldJob.requires) {
         newJob.requires = [].concat(oldJob.requires);
     } // otherwise, keep it the same, or don't set if it wasn't set

--- a/test/data/basic-job-with-images.json
+++ b/test/data/basic-job-with-images.json
@@ -15,6 +15,7 @@
             "name": "hello"
           }
         ],
+        "description": "This is the main description",
         "environment": {
           "SD_TEMPLATE_FULLNAME": "ImagesTestNamespace/imagestemplate",
           "SD_TEMPLATE_NAME": "imagestemplate",


### PR DESCRIPTION
## Context

Job description missing when job is using template.

## Objective

This PR adds job description even if job is using template.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2478

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
