### PR TITLE
fix: try to speed up coverage step by increasing memory

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,6 +5,7 @@ jobs:
     main:
         environment:
             SD_SONAR_OPTS: "-Dsonar.sources=index.js,lib -Dsonar.tests=test -Dsonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info -Dsonar.testExecutionReportPaths=artifacts/report/test.xml"
+            NODE_OPTIONS: "--max_old_space_size=4096"
         steps:
             - install: npm install
             - test: npm test

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,13 +5,14 @@ jobs:
     main:
         environment:
             SD_SONAR_OPTS: "-Dsonar.sources=index.js,lib -Dsonar.tests=test -Dsonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info -Dsonar.testExecutionReportPaths=artifacts/report/test.xml"
-            NODE_OPTIONS: "--max_old_space_size=4096"
         steps:
             - install: npm install
             - test: npm test
         requires:
             - ~pr
             - ~commit
+        annotations:
+            screwdriver.cd/cpu: HIGH
 
     publish:
         template: screwdriver-cd/semantic-release


### PR DESCRIPTION
## Context

Noticed that the coverage step takes >10mins on average for the config-parser pipeline.

## Objective

This PR increases memory to see if that helps speed up that step.

## References

<img width="1794" alt="Screen Shot 2021-06-10 at 3 42 00 PM" src="https://user-images.githubusercontent.com/3230529/121606154-79f86780-ca02-11eb-813d-8eefa3907428.png">

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
