### PR TITLE
feat(2624): Support to define parameters in SDV4 templates

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -360,6 +360,7 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
             }
         }
 
+        // Include parameters from the template only if it not overwritten either in pipeline or job parameters
         if (newJob.parameters !== undefined) {
             const mergedJobParameters = oldJob.parameters || {};
             const mergedJobParameterNames = Object.keys(mergedJobParameters);

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -66,7 +66,7 @@ function flattenCacheSettings(cacheConfig, jobs) {
  * @param  {Boolean}  fromTemplate  Whether this is merged from template. If true, perform extra actions such as wrapping.
  */
 function merge(newJob, oldJob, fromTemplate) {
-    // Intialize new job with default fields (environment, settings, and secrets)
+    // Initialize new job with default fields (environment, settings, and secrets)
     newJob.annotations = newJob.annotations || {};
     newJob.environment = newJob.environment || {};
     newJob.settings = newJob.settings || {};
@@ -99,10 +99,6 @@ function merge(newJob, oldJob, fromTemplate) {
 
     if (oldJob.order) {
         newJob.order = [].concat(oldJob.order);
-    }
-
-    if (oldJob.parameters) {
-        newJob.parameters = oldJob.parameters;
     }
 
     if (oldJob.provider) {
@@ -302,13 +298,15 @@ function flattenSharedIntoJobs(shared, jobs) {
  * Retrieve template and merge into job config
  *
  * @method mergeTemplateIntoJob
- * @param  {String}           jobName           Job name
- * @param  {Object}           jobConfig         Job config
- * @param  {Object}           newJobs           Object with all the jobs
- * @param  {TemplateFactory}  templateFactory   Template Factory to get templates
+ * @param  {String}           jobName               Job name
+ * @param  {Object}           jobConfig             Job config
+ * @param  {Object}           newJobs               Object with all the jobs
+ * @param  {TemplateFactory}  templateFactory       Template Factory to get templates
+ * @param  {Object}           sharedConfig          Shared configuration
+ * @param  {Object}           pipelineParameters    Pipeline level parameters
  * @return {Promise}
  */
-function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, sharedConfig) {
+function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, sharedConfig, pipelineParameters) {
     const oldJob = jobConfig;
 
     // Try to get the template
@@ -362,6 +360,24 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
             }
         }
 
+        if (newJob.parameters !== undefined) {
+            const mergedJobParameters = oldJob.parameters || {};
+            const mergedJobParameterNames = Object.keys(mergedJobParameters);
+            const pipelineParameterNames = Object.keys(pipelineParameters || {});
+
+            for (const [key, value] of Object.entries(newJob.parameters)) {
+                if (!mergedJobParameterNames.includes(key) && !pipelineParameterNames.includes(key)) {
+                    mergedJobParameters[key] = value;
+                }
+            }
+
+            if (Object.keys(mergedJobParameters).length > 0) {
+                newJob.parameters = mergedJobParameters;
+            } else {
+                delete newJob.parameters;
+            }
+        }
+
         warnings = merge(newJob, oldJob, true);
 
         delete newJob.template;
@@ -391,7 +407,7 @@ function mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shar
 function flattenTemplates(doc, templateFactory) {
     const newJobs = {};
     const templates = [];
-    const { jobs, shared } = doc;
+    const { jobs, shared, parameters } = doc;
 
     Object.keys(jobs).forEach(jobName => {
         const jobConfig = clone(jobs[jobName]);
@@ -408,7 +424,7 @@ function flattenTemplates(doc, templateFactory) {
 
         // If template is specified, then merge
         if (templateConfig) {
-            templates.push(mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shared));
+            templates.push(mergeTemplateIntoJob(jobName, jobConfig, newJobs, templateFactory, shared, parameters));
         } else {
             newJobs[jobName] = jobConfig; // Otherwise just use jobConfig
         }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "joi": "^17.4.2",
     "js-yaml": "^3.14.1",
     "keymbinatorial": "^1.2.0",
-    "screwdriver-data-schema": "^21.9.0",
+    "screwdriver-data-schema": "^21.15.0",
     "screwdriver-notifications-email": "^2.2.0",
     "screwdriver-notifications-slack": "^3.2.1",
     "screwdriver-workflow-parser": "^3.2.0",

--- a/test/data/basic-job-with-parameters.json
+++ b/test/data/basic-job-with-parameters.json
@@ -29,7 +29,8 @@
         "settings": {},
         "templateId": 9,
         "parameters": {
-          "color": [ "red", "blue" ]
+          "color": [ "red", "blue" ],
+          "sports": [ "baseball", "basketball" ]
         }
       }
     ]

--- a/test/data/templateWithParameters.json
+++ b/test/data/templateWithParameters.json
@@ -7,13 +7,15 @@
   "maintainer": "foo@bar.com",
   "labels": [],
   "config": {
+    "parameters": {
+      "music": [ "country", "hip hop" ],
+      "color": [ "black", "white" ],
+      "sports": [ "baseball", "basketball" ]
+    },
     "image": "node:4",
     "steps": [
       { "install": "npm install" },
       { "hello": "echo hello world" }
-    ],
-    "parameters": {
-      "music": [ "jazz", "rock" ]
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Context

Parameters can be defined only in Screwdriver pipeline configuration and but not in templates. We need provide a way to define parameters in sdv4 template so not everyone needs to add it when they use the sdv4 template.

## Objective
Merge parameters from template into job level parameters only if it not overwritten in job/pipeline parameters in the screwdriver configuration.
This ensures following order of preference when parameter is looked up in the meta-cli: `template` < `pipeline` < `job`

## References

https://github.com/screwdriver-cd/screwdriver/issues/2624

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
