### PR TITLE
fix: Repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/config-parser.git"
+    "url": "git+https://github.com/screwdriver-cd/config-parser.git"
   },
   "homepage": "https://github.com/screwdriver-cd/config-parser",
   "bugs": "https://github.com/screwdriver-cd/config-parser/issues",


### PR DESCRIPTION
## Context

Semantic release is failing:
```
19:17:46 The authenticity of host 'github.com (192.30.255.113)' can't be established.
19:17:46 ECDSA key fingerprint is SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM.
20:47:23 Are you sure you want to continue connecting (yes/no)?
```
## Objective

This PR fixes checkout URL for repo.

## References

Related to https://github.com/screwdriver-cd/config-parser/pull/130
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
