### PR TITLE
fix: add job image name validation after replace environment

### DIFF
--- a/lib/phase/permutation.js
+++ b/lib/phase/permutation.js
@@ -4,6 +4,7 @@ const Hoek = require('@hapi/hoek');
 const TinyTim = require('tinytim');
 const clone = require('clone');
 const keymbinatorial = require('keymbinatorial');
+const SCHEMA_IMAGE = require('screwdriver-data-schema').config.job.image;
 
 /**
  * Permutation Phase
@@ -12,96 +13,105 @@ const keymbinatorial = require('keymbinatorial');
  * @param   {Object}   validatedDoc Document that went through functional validation
  * @returns {Promise}
  */
-module.exports = validatedDoc =>
-    new Promise(resolve => {
-        const doc = validatedDoc;
+module.exports = async validatedDoc => {
+    const doc = validatedDoc;
 
-        // Generate permutations for each job
-        Object.keys(doc.jobs).forEach(jobName => {
-            const job = {
-                annotations: Hoek.reach(doc, `jobs.${jobName}.annotations`, {
-                    default: {}
-                }),
-                commands: Hoek.reach(doc, `jobs.${jobName}.commands`),
-                environment: Hoek.reach(doc, `jobs.${jobName}.environment`, {
-                    default: {}
-                }),
-                image: Hoek.reach(doc, `jobs.${jobName}.image`),
-                secrets: Hoek.reach(doc, `jobs.${jobName}.secrets`),
-                settings: Hoek.reach(doc, `jobs.${jobName}.settings`, {
-                    default: {}
-                })
-            };
-
-            if (doc.jobs[jobName].cache !== undefined) {
-                job.cache = doc.jobs[jobName].cache;
-            }
-
-            if (doc.jobs[jobName].description !== undefined) {
-                job.description = doc.jobs[jobName].description;
-            }
-
-            if (doc.jobs[jobName].templateId !== undefined) {
-                job.templateId = doc.jobs[jobName].templateId;
-            }
-
-            if (doc.jobs[jobName].parameters !== undefined) {
-                job.parameters = doc.jobs[jobName].parameters;
-            }
-
-            if (doc.jobs[jobName].provider !== undefined) {
-                job.provider = doc.jobs[jobName].provider;
-            }
-
-            // If has the requires/blockedby/freezeWindows key, then set it
-            if (doc.jobs[jobName].requires !== undefined) {
-                job.requires = doc.jobs[jobName].requires;
-            }
-            if (doc.jobs[jobName].blockedBy !== undefined) {
-                job.blockedBy = doc.jobs[jobName].blockedBy;
-            }
-            if (doc.jobs[jobName].freezeWindows !== undefined) {
-                job.freezeWindows = doc.jobs[jobName].freezeWindows;
-            }
-
-            // If doesn't have sourcePaths, then don't set it
-            if (doc.jobs[jobName].sourcePaths.length > 0) {
-                job.sourcePaths = doc.jobs[jobName].sourcePaths;
-            }
-
-            const matrix = Hoek.reach(doc, `jobs.${jobName}.matrix`, {
+    // Generate permutations for each job
+    Object.keys(doc.jobs).forEach(jobName => {
+        const job = {
+            annotations: Hoek.reach(doc, `jobs.${jobName}.annotations`, {
                 default: {}
+            }),
+            commands: Hoek.reach(doc, `jobs.${jobName}.commands`),
+            environment: Hoek.reach(doc, `jobs.${jobName}.environment`, {
+                default: {}
+            }),
+            image: Hoek.reach(doc, `jobs.${jobName}.image`),
+            secrets: Hoek.reach(doc, `jobs.${jobName}.secrets`),
+            settings: Hoek.reach(doc, `jobs.${jobName}.settings`, {
+                default: {}
+            })
+        };
+
+        if (doc.jobs[jobName].cache !== undefined) {
+            job.cache = doc.jobs[jobName].cache;
+        }
+
+        if (doc.jobs[jobName].description !== undefined) {
+            job.description = doc.jobs[jobName].description;
+        }
+
+        if (doc.jobs[jobName].templateId !== undefined) {
+            job.templateId = doc.jobs[jobName].templateId;
+        }
+
+        if (doc.jobs[jobName].parameters !== undefined) {
+            job.parameters = doc.jobs[jobName].parameters;
+        }
+
+        if (doc.jobs[jobName].provider !== undefined) {
+            job.provider = doc.jobs[jobName].provider;
+        }
+
+        // If has the requires/blockedby/freezeWindows key, then set it
+        if (doc.jobs[jobName].requires !== undefined) {
+            job.requires = doc.jobs[jobName].requires;
+        }
+        if (doc.jobs[jobName].blockedBy !== undefined) {
+            job.blockedBy = doc.jobs[jobName].blockedBy;
+        }
+        if (doc.jobs[jobName].freezeWindows !== undefined) {
+            job.freezeWindows = doc.jobs[jobName].freezeWindows;
+        }
+
+        // If doesn't have sourcePaths, then don't set it
+        if (doc.jobs[jobName].sourcePaths.length > 0) {
+            job.sourcePaths = doc.jobs[jobName].sourcePaths;
+        }
+
+        const matrix = Hoek.reach(doc, `jobs.${jobName}.matrix`, {
+            default: {}
+        });
+        const tasks = [];
+        const permutations = keymbinatorial(matrix);
+
+        permutations.forEach(permutation => {
+            const newTask = clone(job);
+            const stringPermutation = permutation;
+
+            // Convert all values to string
+            Object.keys(permutation).forEach(varName => {
+                switch (typeof permutation[varName]) {
+                    case 'object':
+                    case 'number':
+                    case 'boolean':
+                        stringPermutation[varName] = JSON.stringify(permutation[varName]);
+                        break;
+                    default:
+                }
             });
-            const tasks = [];
-            const permutations = keymbinatorial(matrix);
 
-            permutations.forEach(permutation => {
-                const newTask = clone(job);
-                const stringPermutation = permutation;
+            Object.assign(newTask.environment, stringPermutation);
 
-                // Convert all values to string
-                Object.keys(permutation).forEach(varName => {
-                    switch (typeof permutation[varName]) {
-                        case 'object':
-                        case 'number':
-                        case 'boolean':
-                            stringPermutation[varName] = JSON.stringify(permutation[varName]);
-                            break;
-                        default:
-                    }
-                });
+            // Replace any {{environment-keys}} in the image name with the values
+            // node:{{NODE_VERSION}} with NODE_VERSION=6 becomes node:6
+            newTask.image = TinyTim.tim(newTask.image, newTask.environment);
 
-                Object.assign(newTask.environment, stringPermutation);
-
-                // Replace any {{environment-keys}} in the image name with the values
-                // node:{{NODE_VERSION}} with NODE_VERSION=6 becomes node:6
-                newTask.image = TinyTim.tim(newTask.image, newTask.environment);
-
-                tasks.push(newTask);
+            // Validate the following image name
+            // some-image:{{TAG}} with TAG='$(VERSION)' becomes some-image:$(VERSION)
+            const { error } = SCHEMA_IMAGE.label(`jobs.${jobName}.image`).validate(newTask.image, {
+                abortEarly: false
             });
 
-            doc.jobs[jobName] = tasks;
+            if (error) {
+                throw error;
+            }
+
+            tasks.push(newTask);
         });
 
-        resolve(doc);
+        doc.jobs[jobName] = tasks;
     });
+
+    return doc;
+};

--- a/test/data/bad-job-with-image.yaml
+++ b/test/data/bad-job-with-image.yaml
@@ -1,0 +1,3 @@
+jobs:
+    main:
+        image: node:(12)

--- a/test/data/bad-replace-image.yaml
+++ b/test/data/bad-replace-image.yaml
@@ -1,0 +1,7 @@
+jobs:
+    main:
+        image: node:{{TAG}}
+        environment:
+            TAG: (12)
+        steps:
+            - test: echo 'a'

--- a/test/data/replace-image.yaml
+++ b/test/data/replace-image.yaml
@@ -1,0 +1,7 @@
+jobs:
+    main:
+        image: node:{{TAG}}
+        environment:
+            TAG: 12
+        steps:
+            - test: echo 'a'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,6 +105,14 @@ describe('config parser', () => {
                 parser({ yaml: loadData('missing-main-job-with-requires.yaml') }).then(data => {
                     assert.notOk(data.errors);
                 }));
+
+            it('returns an error if bad image name', () =>
+                parser({ yaml: loadData('bad-job-with-image.yaml') }).then(data => {
+                    assert.match(
+                        data.errors[0],
+                        /ValidationError: "jobs.main.image" with value "node:\(12\)" fails to match the required pattern:/
+                    );
+                }));
         });
 
         describe('steps', () => {
@@ -815,5 +823,20 @@ describe('config parser', () => {
             parser({ yaml: loadData('pipeline-with-requires-external.yaml') }).then(data => {
                 assert.deepEqual(data, JSON.parse(loadData('pipeline-with-requires-external.json')));
             }));
+
+        describe('replace image name', () => {
+            it('replace correct image name', () =>
+                parser({ yaml: loadData('replace-image.yaml') }).then(data => {
+                    assert.strictEqual(data.jobs.main[0].image, 'node:12');
+                }));
+
+            it('returns an error if replace bad image name', () =>
+                parser({ yaml: loadData('bad-replace-image.yaml') }).then(data => {
+                    assert.match(
+                        data.errors[0],
+                        /ValidationError: "jobs.main.image" with value "node:\(12\)" fails to match the required pattern:/
+                    );
+                }));
+        });
     });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When we use the validator for the following `screwdriver.yaml`, then the response is `500 Internal Server Error` and the validator does NOT show error messages.

```yaml
jobs:
  main:
    requires: [ ~pr, ~commit ]
    image: node:{{TAG}}
    environment:
      TAG: $SOME_ENV_NAME
    steps:
      - echo: echo 'foo'
```

Since there is no check for replaced image name, the response's job image name is `node:$SOME_ENV_NAME` and this includes `"$"`.
Thus the validator throws an error at [response schema](https://github.com/screwdriver-cd/screwdriver/blob/8ee441ffbfc2c17e9246cc4c2a40ee1e944c2121/plugins/validator.js#L45-L47).

This also occurs on PR builds. If we create a malicious PR then the pipeline page will be 404.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add check for build image name after replaced `{{TAG}}` by environment variables.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
