### PR TITLE
fix: Pull in jobDisabledByDefault annotation change

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.2.1",
+    "@hapi/hoek": "^9.3.0",
     "clone": "^2.1.2",
     "joi": "^17.4.2",
     "js-yaml": "^3.14.1",
     "keymbinatorial": "^1.2.0",
-    "screwdriver-data-schema": "^21.23.0",
+    "screwdriver-data-schema": "^21.23.1",
     "screwdriver-notifications-email": "^2.2.0",
     "screwdriver-notifications-slack": "^3.2.1",
     "screwdriver-workflow-parser": "^3.2.1",


### PR DESCRIPTION
## Context

Sometimes users might have repos/pipelines with build periodic configs. If developers fork and create their own pipelines, they might not want these cron jobs to get auto triggered. It would be nice to have an additional annotation for disabling jobs upon creation so users are required to consciously enable them if they want the periodic builds.

## Objective

This PR pulls in latest data-schema with new `screwdriver.cd/jobDisabledByDefault: true` annotation.

## References

Blocked by https://github.com/screwdriver-cd/data-schema/pull/488

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
