### PR TITLE
feat(2669): Add stages to yaml parser [2]

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,6 +207,12 @@ module.exports = function configParser({
                     delete res.childPipelines;
                 }
 
+                const stages = Hoek.reach(doc, 'stages', { default: {} });
+
+                if (!Hoek.deepEqual(stages, {})) {
+                    res.stages = stages;
+                }
+
                 return res;
             })
             .catch(err => ({

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "debug": false
   },
   "engines": {
-    "node": ">=8.16.0"
+    "node": ">=12.0.0"
   },
   "engine-strict": true,
   "devDependencies": {

--- a/test/data/bad-stages.yaml
+++ b/test/data/bad-stages.yaml
@@ -1,0 +1,12 @@
+stages:
+      description: For canary deployment
+      jobs: [main, publish]
+      color: '#FFFF00'
+jobs:
+    main:
+        template: mynamespace/mytemplate@1.2.3
+        environment:
+            FOO: 'overwritten by job'
+        requires:
+            - ~pr
+            - ~commit

--- a/test/data/pipeline-with-stages.json
+++ b/test/data/pipeline-with-stages.json
@@ -1,0 +1,82 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "image": "node:4",
+                "requires": ["~commit"],
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish"
+                    }
+                ]
+            }
+        ],
+        "foobar": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": ["main"],
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "echo-hello",
+                        "command": "echo hello"
+                    }
+                ]
+            }
+        ],
+        "baz": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "echo-world",
+                        "command": "echo world"
+                    }
+                ]
+            }
+        ]
+    },
+    "stages": {
+        "canary": {
+            "color": "#FFFF00",
+            "description": "For canary deployment",
+            "jobs": ["main", "publish"]
+        }
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "foobar" },
+            { "name": "baz" }
+        ],
+        "edges": [
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "foobar" }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/pipeline-with-stages.yaml
+++ b/test/data/pipeline-with-stages.yaml
@@ -1,0 +1,22 @@
+stages:
+    canary:
+        description: For canary deployment
+        jobs: [main, publish]
+        color: '#FFFF00'
+
+shared:
+    image: node:4
+jobs:
+    main:
+        steps:
+            - install: npm install
+            - test: npm test
+            - publish: npm publish
+        requires: ~commit
+    foobar:
+        steps:
+            - echo-hello: echo hello
+        requires: main
+    baz:
+        steps:
+            - echo-world: echo world

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -165,6 +165,18 @@ describe('config parser', () => {
                 }));
         });
 
+        describe('stages', () => {
+            it('returns a yaml with stages in correct format', () =>
+                parser({ yaml: loadData('pipeline-with-stages.yaml') }).then(data => {
+                    assert.deepEqual(data, JSON.parse(loadData('pipeline-with-stages.json')));
+                }));
+
+            it('returns an error if bad stages', () =>
+                parser({ yaml: loadData('bad-stages.yaml') }).then(data => {
+                    assert.match(data.jobs.main[0].commands[0].command, /"stages.description" must be of type object./);
+                }));
+        });
+
         describe('subscribe', () => {
             it('fetches subscribe from the config and adds to parsed doc', () =>
                 parser({ yaml: loadData('pipeline-with-subscribed-scms.yaml') }).then(data => {


### PR DESCRIPTION
## Context

Users might want to group jobs together visually in the UI into stages.

## Objective

This PR adds stages to the parser.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
