### PR TITLE
fix(2767): Non-terminal jobs of a stage could be added to 'requires' of teardown job

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -555,7 +555,7 @@ function getFullStageName({ stageName, type }) {
  * @return {Array}                  Teardown requires
  */
 function getTeardownRequires(jobs, stageName) {
-    const stageJobsRequires = [];
+    let stageJobsRequires = [];
     const stageJobNames = [];
 
     // Find jobs that belong to the stage
@@ -563,7 +563,7 @@ function getTeardownRequires(jobs, stageName) {
     Object.keys(jobs).forEach(jobName => {
         if (jobs[jobName].stage && jobs[jobName].stage.name === stageName) {
             if (Array.isArray(jobs[jobName].requires)) {
-                stageJobsRequires.concat(jobs[jobName].requires);
+                stageJobsRequires = stageJobsRequires.concat(jobs[jobName].requires);
             } else {
                 stageJobsRequires.push(jobs[jobName].requires);
             }
@@ -572,11 +572,9 @@ function getTeardownRequires(jobs, stageName) {
     });
 
     // Get terminal nodes
-    const teardownRequires = stageJobNames.filter(
+    return stageJobNames.filter(
         jobName => !stageJobsRequires.includes(jobName) && !stageJobsRequires.includes(`~${jobName}`)
     );
-
-    return teardownRequires;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^22.0.0",
+    "screwdriver-data-schema": "^22.7.1",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
-    "screwdriver-workflow-parser": "^4.0.0",
+    "screwdriver-workflow-parser": "^4.1.0",
     "shell-escape": "^0.2.0",
     "tinytim": "^0.1.1"
   }

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs.json
@@ -50,6 +50,25 @@
                 }
             }
         ],
+        "docker-publish": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": ["publish"],
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "echo-docker",
+                        "command": "echo docker"
+                    }
+                ],
+                "stage": {
+                    "name": "canary"
+                }
+            }
+        ],
         "baz": [
             {
                 "annotations": {},
@@ -96,7 +115,7 @@
                 "settings": {},
                 "environment": {},
                 "requires": [
-                    "publish"
+                    "docker-publish"
                 ],
                 "image": "node:18",
                 "commands": [
@@ -114,7 +133,7 @@
     "stages": {
         "canary": {
             "description": "For canary deployment",
-            "jobs": ["main", "publish"],
+            "jobs": ["main", "publish", "docker-publish"],
             "requires": "baz"
         }
     },
@@ -125,15 +144,17 @@
             { "name": "main", "stageName": "canary" },
             { "name": "stage@canary:setup", "stageName": "canary" },
             { "name": "publish", "stageName": "canary" },
+            { "name": "docker-publish", "stageName": "canary" },
             { "name": "baz" },
             { "name": "stage@canary:teardown", "stageName": "canary" }
         ],
         "edges": [
             { "src": "stage@canary:setup", "dest": "main" },
             { "src": "main", "dest": "publish" },
+            { "src": "publish", "dest": "docker-publish" },
             { "src": "~commit", "dest": "baz" },
             { "src": "baz", "dest": "stage@canary:setup" },
-            { "src": "publish", "dest": "stage@canary:teardown" }
+            { "src": "docker-publish", "dest": "stage@canary:teardown" }
         ]
     },
     "subscribe": {}

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs.yaml
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs.yaml
@@ -2,7 +2,7 @@ stages:
     canary:
         requires: baz
         description: For canary deployment
-        jobs: [main, publish]
+        jobs: [main, publish, docker-publish]
         teardown:
             image: node:18
             steps:
@@ -20,7 +20,11 @@ jobs:
     publish:
         steps:
             - echo-hello: echo hello
-        requires: main
+        requires: [ main ]
+    docker-publish:
+        steps:
+            - echo-docker: echo docker
+        requires: publish
     baz:
         requires: ~commit
         steps:


### PR DESCRIPTION
## Context

Non-terminal jobs of a stage could be added to 'requires' of teardown job.
This happens when such jobs appear in `requires` of another job declared as an array.
Ex: 
`requires: [main]` -> `main` is considered as a terminal job which is incorrect.
vs
`requires: main`  -> `main` is not considered as a terminal job as expected.

## Objective
Exclude the job when they appear in `requires` of another job even when declared as an array.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2767
https://github.com/screwdriver-cd/config-parser/pull/143

## License

<!-- The following line must be included in your pull request -->
https://github.com/screwdriver-cd/config-parser/pull/143

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
