### PR TITLE
fix(2980): Fix tests to align to workflow-parser changes

### DIFF
--- a/test/data/basic-job-with-template-with-namespace.json
+++ b/test/data/basic-job-with-template-with-namespace.json
@@ -66,7 +66,7 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "publish" }
+            { "src": "main", "dest": "publish", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/basic-job-with-template.json
+++ b/test/data/basic-job-with-template.json
@@ -68,7 +68,7 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "publish" }
+            { "src": "main", "dest": "publish", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/basic-shared-project-empty-settings.json
+++ b/test/data/basic-shared-project-empty-settings.json
@@ -187,7 +187,7 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "foobar" }
+            { "src": "main", "dest": "foobar", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/basic-shared-project.json
+++ b/test/data/basic-shared-project.json
@@ -189,7 +189,7 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "foobar" }
+            { "src": "main", "dest": "foobar", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/build-cluster.json
+++ b/test/data/build-cluster.json
@@ -74,8 +74,8 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "test" },
-            { "src": "test", "dest": "publish" }
+            { "src": "main", "dest": "test", "join": true },
+            { "src": "test", "dest": "publish", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/node-module.json
+++ b/test/data/node-module.json
@@ -118,7 +118,7 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "publish" }
+            { "src": "main", "dest": "publish", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/pipeline-cache-false-job.json
+++ b/test/data/pipeline-cache-false-job.json
@@ -96,8 +96,8 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "test" },
-            { "src": "test", "dest": "publish" }
+            { "src": "main", "dest": "test", "join": true },
+            { "src": "test", "dest": "publish", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/pipeline-cache.json
+++ b/test/data/pipeline-cache.json
@@ -109,8 +109,8 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "test" },
-            { "src": "test", "dest": "publish" }
+            { "src": "main", "dest": "test", "join": true },
+            { "src": "test", "dest": "publish", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/pipeline-with-childPipelines.json
+++ b/test/data/pipeline-with-childPipelines.json
@@ -75,7 +75,7 @@
         ],
         "edges": [
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "foobar" }
+            { "src": "main", "dest": "foobar", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/pipeline-with-requires-external.json
+++ b/test/data/pipeline-with-requires-external.json
@@ -67,7 +67,7 @@
         ],
         "edges": [
             { "src": "~commit", "dest": "A" },
-            { "src": "A", "dest": "D" },
+            { "src": "A", "dest": "D", "join": true },
             { "src": "D", "dest": "E", "join": true },
             { "src": "sd@123:B", "dest": "E", "join": true },
             { "src": "sd@456:C", "dest": "E", "join": true }

--- a/test/data/pipeline-with-requires.json
+++ b/test/data/pipeline-with-requires.json
@@ -112,7 +112,7 @@
         ],
         "edges": [
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "foobar" },
+            { "src": "main", "dest": "foobar", "join": true },
             { "src": "foobar", "dest": "test-or" },
             { "src": "main", "dest": "test-or" },
             { "src": "foobar", "dest": "test-and", "join": true },

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs.json
@@ -150,11 +150,11 @@
         ],
         "edges": [
             { "src": "stage@canary:setup", "dest": "main" },
-            { "src": "main", "dest": "publish" },
-            { "src": "publish", "dest": "docker-publish" },
+            { "src": "main", "dest": "publish", "join": true },
+            { "src": "publish", "dest": "docker-publish", "join": true },
             { "src": "~commit", "dest": "baz" },
-            { "src": "baz", "dest": "stage@canary:setup" },
-            { "src": "docker-publish", "dest": "stage@canary:teardown" }
+            { "src": "baz", "dest": "stage@canary:setup", "join": true },
+            { "src": "docker-publish", "dest": "stage@canary:teardown", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/shared-annotations.json
+++ b/test/data/shared-annotations.json
@@ -207,7 +207,7 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "foobar" }
+            { "src": "main", "dest": "foobar", "join": true }
         ]
     },
     "subscribe": {}


### PR DESCRIPTION
## Context

With the changes made to workflow-parser https://github.com/screwdriver-cd/workflow-parser/pull/49, `join: true` will be set on the workflow graph `edge` even when the destination `node` has only one upstream. 

Due to this change, the tests in `config-parser` are broken https://cd.screwdriver.cd/pipelines/18/builds/923526/steps/test

## Objective

Update tests to expect `join: true` wherever applicable.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2980

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
