### PR TITLE
feat(3026): Fill-in stage setup/teardown triggers in job 'requires'

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -2,6 +2,7 @@
 
 const Hoek = require('@hapi/hoek');
 const clone = require('clone');
+const { STAGE_TRIGGER } = require('screwdriver-data-schema/config/regex');
 
 const STAGE_PREFIX = 'stage@';
 const DEFAULT_JOB = { image: 'node:18', steps: [{ noop: 'echo noop' }] };
@@ -542,9 +543,9 @@ function convertSteps(jobs) {
  * Get full stage name
  * @param  {String} stageName               Stage name
  * @param  {String} type                    Type of stage job (setup or teardown)
- * @return {String}                         Full stage name (e.g. stage@deploy:setup)
+ * @return {String}                         Full stage job name (e.g. stage@deploy:setup)
  */
-function getFullStageName({ stageName, type }) {
+function getFullStageJobName({ stageName, type }) {
     return `${STAGE_PREFIX}${stageName}:${type}`;
 }
 
@@ -579,6 +580,28 @@ function getTeardownRequires(jobs, stageName) {
 
 /**
  * Flatten stage setup and teardown into jobs object
+ * @param  {Object} job               Document that went through structural parsing
+ */
+function convertStageTriggerToTeardownTrigger(job) {
+    const converterFn = trigger => {
+        const result = trigger.match(STAGE_TRIGGER);
+
+        if (result && !result[2]) {
+            return `${trigger}:teardown`;
+        }
+
+        return trigger;
+    };
+
+    if (Array.isArray(job.requires)) {
+        job.requires = job.requires.map(converterFn);
+    } else {
+        job.requires = converterFn(job.requires);
+    }
+}
+
+/**
+ * Flatten stage setup and teardown into jobs object
  * @param  {Object} doc               Document that went through structural parsing
  */
 function flattenStageSetupAndTeardownJobs(doc) {
@@ -587,18 +610,24 @@ function flattenStageSetupAndTeardownJobs(doc) {
 
     if (stages) {
         Object.keys(stages).forEach(stageName => {
-            const { setup, teardown, jobs: stageJobs } = stages[stageName];
+            const { setup, teardown, jobs: stageJobNames } = stages[stageName];
             let stageSetup = setup;
             let stageTeardown = teardown;
 
-            stageJobs.forEach(jobName => {
-                if (newJobs[jobName]) {
-                    newJobs[jobName].stage = { name: stageName };
+            Object.entries(newJobs).forEach(([jobName, job]) => {
+                if (stageJobNames.includes(jobName)) {
+                    job.stage = { name: stageName };
+
+                    if (!job.requires || job.requires.length === 0) {
+                        job.requires = `~${getFullStageJobName({ stageName, type: 'setup' })}`;
+                    }
+                } else if (job.requires) {
+                    convertStageTriggerToTeardownTrigger(job);
                 }
             });
 
-            const setupStageName = getFullStageName({ stageName, type: 'setup' });
-            const teardownStageName = getFullStageName({ stageName, type: 'teardown' });
+            const setupStageName = getFullStageJobName({ stageName, type: 'setup' });
+            const teardownStageName = getFullStageJobName({ stageName, type: 'teardown' });
 
             // Implicitly create setup/teardown
             if (Hoek.deepEqual(stageSetup, {})) {

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -579,8 +579,13 @@ function getTeardownRequires(jobs, stageName) {
 }
 
 /**
- * Flatten stage setup and teardown into jobs object
- * @param  {Object} job               Document that went through structural parsing
+ * Expands stage triggers specified in 'job.requires' to stage teardown job triggers
+ * Examples:
+ * [stage@canary, ~stage:performance, A, B, ~C] -> [stage@canary:teardown, ~stage:performance:teardown, A, B, ~C]
+ * stage@canary -> stage@canary:teardown
+ * [] -> []
+ *
+ * @param  {Object} job               Job
  */
 function convertStageTriggerToTeardownTrigger(job) {
     const converterFn = trigger => {

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-explicit.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-explicit.json
@@ -1,0 +1,180 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "image": "node:4",
+                "requires": [
+                    "~stage@canary:setup"
+                ],
+                "commands": [
+                    {
+                        "name": "install",
+                        "command": "npm install"
+                    },
+                    {
+                        "name": "test",
+                        "command": "npm test"
+                    },
+                    {
+                        "name": "publish",
+                        "command": "npm publish"
+                    }
+                ],
+                "stage": {
+                    "name": "canary"
+                }
+            }
+        ],
+        "publish": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": ["main"],
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "echo-hello",
+                        "command": "echo hello"
+                    }
+                ],
+                "stage": {
+                    "name": "canary"
+                }
+            }
+        ],
+        "docker-publish": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": ["publish"],
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "echo-docker",
+                        "command": "echo docker"
+                    }
+                ],
+                "stage": {
+                    "name": "canary"
+                }
+            }
+        ],
+        "baz": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "image": "node:4",
+                "commands": [
+                    {
+                        "name": "echo-world",
+                        "command": "echo world"
+                    }
+                ],
+                "requires": [
+                    "~commit"
+                ]
+            }
+        ],
+        "stage@canary:setup": [
+            {
+                "annotations": {},
+                "requires": [
+                    "baz"
+                ],
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "image": "node:18",
+                "commands": [
+                    {
+                        "name": "publish",
+                        "command": "pre blog"
+                    }
+                ],
+                "stage": {
+                    "name": "canary"
+                }
+            }
+        ],
+        "stage@canary:teardown": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": [
+                    "docker-publish"
+                ],
+                "image": "node:18",
+                "commands": [
+                    {
+                        "name": "publish",
+                        "command": "post blog"
+                    }
+                ],
+                "stage": {
+                    "name": "canary"
+                }
+            }
+        ],
+        "triggered-after-stage": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": [
+                    "~stage@canary:teardown"
+                ],
+                "image": "node:4",
+                "commands": [{
+                        "command": "echo stage downstream",
+                        "name": "echo-stage-downstream"
+                        }
+                    ]
+            }
+        ]
+    },
+    "stages": {
+        "canary": {
+            "description": "For canary deployment",
+            "jobs": ["main", "publish", "docker-publish"],
+            "requires": "baz"
+        }
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main", "stageName": "canary" },
+            { "name": "stage@canary:setup", "stageName": "canary" },
+            { "name": "publish", "stageName": "canary" },
+            { "name": "docker-publish", "stageName": "canary" },
+            { "name": "baz" },
+            { "name": "triggered-after-stage" },
+            { "name": "stage@canary:teardown", "stageName": "canary" }
+        ],
+        "edges": [
+            { "src": "stage@canary:setup", "dest": "main" },
+            { "src": "main", "dest": "publish", "join": true },
+            { "src": "publish", "dest": "docker-publish", "join": true },
+            { "src": "~commit", "dest": "baz" },
+            { "src": "stage@canary:teardown", "dest": "triggered-after-stage" },
+            { "src": "baz", "dest": "stage@canary:setup", "join": true },
+            { "src": "docker-publish", "dest": "stage@canary:teardown", "join": true }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-explicit.yaml
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-explicit.yaml
@@ -1,0 +1,39 @@
+stages:
+    canary:
+        requires: baz
+        description: For canary deployment
+        jobs: [main, publish, docker-publish]
+        setup:
+            image: node:18
+            steps:
+                - publish: pre blog
+        teardown:
+            image: node:18
+            steps:
+                - publish: post blog
+
+shared:
+    image: node:4
+jobs:
+    main:
+        steps:
+            - install: npm install
+            - test: npm test
+            - publish: npm publish
+        requires: [~stage@canary:setup]
+    publish:
+        steps:
+            - echo-hello: echo hello
+        requires: [ main ]
+    docker-publish:
+        steps:
+            - echo-docker: echo docker
+        requires: publish
+    baz:
+        requires: ~commit
+        steps:
+            - echo-world: echo world
+    triggered-after-stage:
+        requires: [~stage@canary:teardown]
+        steps:
+            - echo-stage-downstream: echo stage downstream

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
@@ -120,13 +120,30 @@
                 "image": "node:18",
                 "commands": [
                     {
-                        "name": "publish",
-                        "command": "post blog"
+                        "name": "noop",
+                        "command": "echo noop"
                     }
                 ],
                 "stage": {
                     "name": "canary"
                 }
+            }
+        ],
+        "triggered-after-stage": [
+            {
+                "annotations": {},
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "requires": [
+                    "~stage@canary:teardown"
+                ],
+                "image": "node:4",
+                "commands": [{
+                        "command": "echo stage downstream",
+                        "name": "echo-stage-downstream"
+                        }
+                    ]
             }
         ]
     },
@@ -146,6 +163,7 @@
             { "name": "publish", "stageName": "canary" },
             { "name": "docker-publish", "stageName": "canary" },
             { "name": "baz" },
+            { "name": "triggered-after-stage" },
             { "name": "stage@canary:teardown", "stageName": "canary" }
         ],
         "edges": [
@@ -153,6 +171,7 @@
             { "src": "main", "dest": "publish", "join": true },
             { "src": "publish", "dest": "docker-publish", "join": true },
             { "src": "~commit", "dest": "baz" },
+            { "src": "stage@canary:teardown", "dest": "triggered-after-stage" },
             { "src": "baz", "dest": "stage@canary:setup", "join": true },
             { "src": "docker-publish", "dest": "stage@canary:teardown", "join": true }
         ]

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.yaml
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.yaml
@@ -3,10 +3,6 @@ stages:
         requires: baz
         description: For canary deployment
         jobs: [main, publish, docker-publish]
-        teardown:
-            image: node:18
-            steps:
-                - publish: post blog
 
 shared:
     image: node:4
@@ -16,7 +12,7 @@ jobs:
             - install: npm install
             - test: npm test
             - publish: npm publish
-        requires: ~stage@canary:setup
+        requires: []
     publish:
         steps:
             - echo-hello: echo hello
@@ -29,3 +25,7 @@ jobs:
         requires: ~commit
         steps:
             - echo-world: echo world
+    triggered-after-stage:
+        requires: [~stage@canary]
+        steps:
+            - echo-stage-downstream: echo stage downstream

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -175,14 +175,30 @@ describe('config parser', () => {
         });
 
         describe('stages', () => {
-            it('returns a yaml with stages in correct format with setup and teardown jobs', () =>
+            it('returns a yaml with stages in correct format when setup and teardown jobs are explicitly defined', () =>
                 parser({
-                    yaml: loadData('pipeline-with-stages-and-setup-teardown-jobs.yaml'),
+                    yaml: loadData('pipeline-with-stages-and-setup-teardown-jobs-explicit.yaml'),
                     templateFactory: templateFactoryMock,
                     triggerFactory,
                     pipelineId
                 }).then(data => {
-                    assert.deepEqual(data, JSON.parse(loadData('pipeline-with-stages-and-setup-teardown-jobs.json')));
+                    assert.deepEqual(
+                        data,
+                        JSON.parse(loadData('pipeline-with-stages-and-setup-teardown-jobs-explicit.json'))
+                    );
+                }));
+
+            it('returns a yaml with stages in correct format when setup and teardown jobs are implicitly created', () =>
+                parser({
+                    yaml: loadData('pipeline-with-stages-and-setup-teardown-jobs-implicit.yaml'),
+                    templateFactory: templateFactoryMock,
+                    triggerFactory,
+                    pipelineId
+                }).then(data => {
+                    assert.deepEqual(
+                        data,
+                        JSON.parse(loadData('pipeline-with-stages-and-setup-teardown-jobs-implicit.json'))
+                    );
                 }));
 
             it('returns an error if bad stages', () =>


### PR DESCRIPTION
## Context

Configuring `setup` and `teardown` for a stage is optional. When not specified, `setup` and `teardown` jobs are implicitly created. 

When they are not explicitly configured,  expecting stage `setup` and `teardown` in a job `requires` to define the workflow could be confusing.
Ex:
```
stages:
    canary:
        jobs: [main, publish]

jobs:
    main:
       requires: [~stage@canary:setup]
       .....
       .....
    publish:
       requires: [main]
       .....
       .....
    job-triggered-after-stage:
       requires: [~stage@canary:teardown]
       .....
       .....
       
```

## Objective
Need below changes:
- Allow stage (Ex: `~stage:canary`) to appear as upstream (i.e. in `requires`) for a job outside the stage. This should get translated to `teardown` (Ex: `~stage:canary:teardown`) when the configuration is parsed.
- If a stage job has no or empty `requires`, set stage `setup` (Ex: `~stage:canary:setup`) as upstream

With these changes the screwdriver yaml configuration could be 
```
stages:
    canary:
        jobs: [main, publish]

jobs:
    main:
       requires: []
       .....
       .....
    publish:
       requires: [main]
       .....
       .....
    job-triggered-after-stage:
       requires: [~stage@canary]
       .....
       .....
       
```

## References

https://github.com/screwdriver-cd/screwdriver/issues/3026

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
