### PR TITLE
feat(3022): Add annotation to mark implicitly created stage setup/teardown jobs are virtual

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -5,7 +5,11 @@ const clone = require('clone');
 const { STAGE_TRIGGER } = require('screwdriver-data-schema/config/regex');
 
 const STAGE_PREFIX = 'stage@';
-const DEFAULT_JOB = { image: 'node:18', steps: [{ noop: 'echo noop' }] };
+const DEFAULT_JOB = {
+    image: 'node:18',
+    steps: [{ noop: 'echo noop' }],
+    annotations: { 'screwdriver.cd/virtualTrigger': true }
+};
 
 /**
  * Check if a job has duplicate steps

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^22.7.1",
+    "screwdriver-data-schema": "^22.11.0",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
     "screwdriver-workflow-parser": "^4.1.0",

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
@@ -89,7 +89,7 @@
         ],
         "stage@canary:setup": [
             {
-                "annotations": {},
+                "annotations": { "screwdriver.cd/virtualTrigger": true },
                 "requires": [
                     "baz"
                 ],
@@ -110,7 +110,7 @@
         ],
         "stage@canary:teardown": [
             {
-                "annotations": {},
+                "annotations": { "screwdriver.cd/virtualTrigger": true },
                 "secrets": [],
                 "settings": {},
                 "environment": {},


### PR DESCRIPTION
## Context
`setup` / `teardown` job for a `stage` are implicitly created if it is not configured in the `screwdriver.yaml`.
We need a mechanism to identify these implicitly created `setup` / `teardown` jobs to take necessary actions.
Ex: skip execution, hide it from workflow graph in the UI, etc

## Objective

This PR adds `screwdriver.cd/virtual: true` annotation to implicitly created `setup`/`teardown` jobs.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
