### PR TITLE
fix(3022): Rename the annotation added to implicitly created stage setup/teardown jobs

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -8,7 +8,7 @@ const STAGE_PREFIX = 'stage@';
 const DEFAULT_JOB = {
     image: 'node:18',
     steps: [{ noop: 'echo noop' }],
-    annotations: { 'screwdriver.cd/virtualTrigger': true }
+    annotations: { 'screwdriver.cd/virtualJob': true }
 };
 
 /**

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
@@ -89,7 +89,7 @@
         ],
         "stage@canary:setup": [
             {
-                "annotations": { "screwdriver.cd/virtualTrigger": true },
+                "annotations": { "screwdriver.cd/virtualJob": true },
                 "requires": [
                     "baz"
                 ],
@@ -110,7 +110,7 @@
         ],
         "stage@canary:teardown": [
             {
-                "annotations": { "screwdriver.cd/virtualTrigger": true },
+                "annotations": { "screwdriver.cd/virtualJob": true },
                 "secrets": [],
                 "settings": {},
                 "environment": {},


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/data-schema/pull/553 renamed the job annotation `screwdriver.cd/virtualTrigger` to `screwdriver.cd/virtualJob`

## Objective

Replace the usage of `screwdriver.cd/virtualTrigger` to `screwdriver.cd/virtualJob`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
