### PR TITLE
feat(3045): Allow a stage to be declared as an upstream for another stage

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -583,29 +583,31 @@ function getTeardownRequires(jobs, stageName) {
 }
 
 /**
- * Expands stage triggers specified in 'job.requires' to stage teardown job triggers
+ * Expands stage triggers specified in 'job.requires' or 'stage.requires' to stage teardown job triggers
  * Examples:
  * [stage@canary, ~stage:performance, A, B, ~C] -> [stage@canary:teardown, ~stage:performance:teardown, A, B, ~C]
  * stage@canary -> stage@canary:teardown
  * [] -> []
  *
- * @param  {Object} job               Job
+ * @param  {Object} stageOrJob               Job
  */
-function convertStageTriggerToTeardownTrigger(job) {
-    const converterFn = trigger => {
-        const result = trigger.match(STAGE_TRIGGER);
+function convertStageTriggerToTeardownTrigger(stageOrJob) {
+    if (stageOrJob.requires) {
+        const converterFn = trigger => {
+            const result = trigger.match(STAGE_TRIGGER);
 
-        if (result && !result[2]) {
-            return `${trigger}:teardown`;
+            if (result && !result[2]) {
+                return `${trigger}:teardown`;
+            }
+
+            return trigger;
+        };
+
+        if (Array.isArray(stageOrJob.requires)) {
+            stageOrJob.requires = stageOrJob.requires.map(converterFn);
+        } else {
+            stageOrJob.requires = converterFn(stageOrJob.requires);
         }
-
-        return trigger;
-    };
-
-    if (Array.isArray(job.requires)) {
-        job.requires = job.requires.map(converterFn);
-    } else {
-        job.requires = converterFn(job.requires);
     }
 }
 
@@ -618,7 +620,7 @@ function flattenStageSetupAndTeardownJobs(doc) {
     const stages = clone(doc.stages);
 
     if (stages) {
-        Object.keys(stages).forEach(stageName => {
+        Object.entries(stages).forEach(([stageName, stage]) => {
             const { setup, teardown, jobs: stageJobNames } = stages[stageName];
             let stageSetup = setup;
             let stageTeardown = teardown;
@@ -630,10 +632,12 @@ function flattenStageSetupAndTeardownJobs(doc) {
                     if (!job.requires || job.requires.length === 0) {
                         job.requires = `~${getFullStageJobName({ stageName, type: 'setup' })}`;
                     }
-                } else if (job.requires) {
+                } else {
                     convertStageTriggerToTeardownTrigger(job);
                 }
             });
+
+            convertStageTriggerToTeardownTrigger(stage);
 
             const setupStageName = getFullStageJobName({ stageName, type: 'setup' });
             const teardownStageName = getFullStageJobName({ stageName, type: 'teardown' });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^22.11.0",
+    "screwdriver-data-schema": "^22.11.1",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
     "screwdriver-workflow-parser": "^4.1.0",

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
@@ -37,7 +37,9 @@
                 "secrets": [],
                 "settings": {},
                 "environment": {},
-                "requires": ["main"],
+                "requires": [
+                    "main"
+                ],
                 "image": "node:4",
                 "commands": [
                     {
@@ -56,7 +58,9 @@
                 "secrets": [],
                 "settings": {},
                 "environment": {},
-                "requires": ["publish"],
+                "requires": [
+                    "publish"
+                ],
                 "image": "node:4",
                 "commands": [
                     {
@@ -89,7 +93,9 @@
         ],
         "stage@canary:setup": [
             {
-                "annotations": { "screwdriver.cd/virtualJob": true },
+                "annotations": {
+                    "screwdriver.cd/virtualJob": true
+                },
                 "requires": [
                     "baz"
                 ],
@@ -110,7 +116,9 @@
         ],
         "stage@canary:teardown": [
             {
-                "annotations": { "screwdriver.cd/virtualJob": true },
+                "annotations": {
+                    "screwdriver.cd/virtualJob": true
+                },
                 "secrets": [],
                 "settings": {},
                 "environment": {},
@@ -129,29 +137,130 @@
                 }
             }
         ],
-        "triggered-after-stage": [
+        "post-release": [
             {
                 "annotations": {},
+                "commands": [
+                    {
+                        "command": "stage downstream job",
+                        "name": "echo"
+                    }
+                ],
+                "environment": {},
+                "image": "node:4",
+                "requires": [
+                    "~stage@production:teardown"
+                ],
+                "secrets": [],
+                "settings": {}
+            }
+        ],
+        "prod-certify": [
+            {
+                "annotations": {},
+                "commands": [
+                    {
+                        "command": "echo production certify",
+                        "name": "echo"
+                    }
+                ],
+                "environment": {},
+                "image": "node:4",
+                "requires": [
+                    "prod-deploy"
+                ],
+                "secrets": [],
+                "settings": {},
+                "stage": {
+                    "name": "production"
+                }
+            }
+        ],
+        "prod-deploy": [
+            {
+                "annotations": {},
+                "commands": [
+                    {
+                        "command": "echo production deployment",
+                        "name": "echo"
+                    }
+                ],
+                "environment": {},
+                "image": "node:4",
+                "requires": [
+                    "~stage@production:setup"
+                ],
+                "secrets": [],
+                "settings": {},
+                "stage": {
+                    "name": "production"
+                }
+            }
+        ],
+        "stage@production:setup": [
+            {
+                "annotations": {
+                    "screwdriver.cd/virtualJob": true
+                },
+                "requires": [
+                    "~stage@canary:teardown"
+                ],
+                "secrets": [],
+                "settings": {},
+                "environment": {},
+                "image": "node:18",
+                "commands": [
+                    {
+                        "name": "noop",
+                        "command": "echo noop"
+                    }
+                ],
+                "stage": {
+                    "name": "production"
+                }
+            }
+        ],
+        "stage@production:teardown": [
+            {
+                "annotations": {
+                    "screwdriver.cd/virtualJob": true
+                },
                 "secrets": [],
                 "settings": {},
                 "environment": {},
                 "requires": [
-                    "~stage@canary:teardown"
+                    "prod-certify"
                 ],
-                "image": "node:4",
-                "commands": [{
-                        "command": "echo stage downstream",
-                        "name": "echo-stage-downstream"
-                        }
-                    ]
+                "image": "node:18",
+                "commands": [
+                    {
+                        "name": "noop",
+                        "command": "echo noop"
+                    }
+                ],
+                "stage": {
+                    "name": "production"
+                }
             }
         ]
     },
     "stages": {
         "canary": {
             "description": "For canary deployment",
-            "jobs": ["main", "publish", "docker-publish"],
+            "jobs": [
+                "main",
+                "publish",
+                "docker-publish"
+            ],
             "requires": "baz"
+        },
+        "production": {
+            "description": "For production deployment",
+            "jobs": [
+                "prod-deploy",
+                "prod-certify"
+            ],
+            "requires": "~stage@canary:teardown"
         }
     },
     "workflowGraph": {
@@ -163,7 +272,11 @@
             { "name": "publish", "stageName": "canary" },
             { "name": "docker-publish", "stageName": "canary" },
             { "name": "baz" },
-            { "name": "triggered-after-stage" },
+            { "name": "prod-deploy", "stageName": "production" },
+            { "name": "stage@production:setup", "stageName": "production" },
+            { "name": "prod-certify", "stageName": "production" },
+            { "name": "post-release" },
+            { "name": "stage@production:teardown", "stageName": "production" },
             { "name": "stage@canary:teardown", "stageName": "canary" }
         ],
         "edges": [
@@ -171,9 +284,13 @@
             { "src": "main", "dest": "publish", "join": true },
             { "src": "publish", "dest": "docker-publish", "join": true },
             { "src": "~commit", "dest": "baz" },
-            { "src": "stage@canary:teardown", "dest": "triggered-after-stage" },
+            { "src": "stage@production:setup", "dest": "prod-deploy" },
+            { "src": "prod-deploy", "dest": "prod-certify", "join": true },
+            { "src": "stage@production:teardown", "dest": "post-release" },
             { "src": "baz", "dest": "stage@canary:setup", "join": true },
-            { "src": "docker-publish", "dest": "stage@canary:teardown", "join": true }
+            { "src": "docker-publish", "dest": "stage@canary:teardown", "join": true },
+            { "src": "stage@canary:teardown", "dest": "stage@production:setup" },
+            { "src": "prod-certify", "dest": "stage@production:teardown", "join": true }
         ]
     },
     "subscribe": {}

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.yaml
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.yaml
@@ -2,30 +2,42 @@ stages:
     canary:
         requires: baz
         description: For canary deployment
-        jobs: [main, publish, docker-publish]
+        jobs: [ main, publish, docker-publish ]
+    production:
+        requires: ~stage@canary
+        description: For production deployment
+        jobs: [ prod-deploy, prod-certify ]
 
 shared:
     image: node:4
 jobs:
     main:
         steps:
-            - install: npm install
-            - test: npm test
-            - publish: npm publish
-        requires: []
+            -   install: npm install
+            -   test: npm test
+            -   publish: npm publish
+        requires: [ ]
     publish:
         steps:
-            - echo-hello: echo hello
+            -   echo-hello: echo hello
         requires: [ main ]
     docker-publish:
         steps:
-            - echo-docker: echo docker
+            -   echo-docker: echo docker
         requires: publish
     baz:
         requires: ~commit
         steps:
-            - echo-world: echo world
-    triggered-after-stage:
-        requires: [~stage@canary]
+            -   echo-world: echo world
+    prod-deploy:
+        requires: [ ]
         steps:
-            - echo-stage-downstream: echo stage downstream
+            -   echo: echo production deployment
+    prod-certify:
+        requires: [ prod-deploy ]
+        steps:
+            -   echo: echo production certify
+    post-release:
+        requires: [ ~stage@production ]
+        steps:
+            -   echo: stage downstream job


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/screwdriver/issues/3045

A stage (Ex: stage@integration) cannot be included in the `requires` of downstream stage.
Current implementation expects the `teardown` job of the upstream stage to be listed in the `requires` of downstream stage.

This could be confusing when `teardown` is not configured in the `screwdriver.yaml` for upstream stage.

## Objective
Allow a stage (Ex: stage@integration) to be included in the requires of downstream stage.
Trigger `stage@integration` should get converted to `stage@integration:teardown` when the configuration is parsed.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3045

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
