### PR TITLE
feat(3022): Update tests to include virtual field in the workflow graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^23.0.0",
+    "screwdriver-data-schema": "^23.1.0",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
-    "screwdriver-workflow-parser": "^4.1.0",
+    "screwdriver-workflow-parser": "^4.3.0",
     "shell-escape": "^0.2.0",
     "tinytim": "^0.1.1"
   }

--- a/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
+++ b/test/data/pipeline-with-stages-and-setup-teardown-jobs-implicit.json
@@ -268,16 +268,16 @@
             { "name": "~pr" },
             { "name": "~commit" },
             { "name": "main", "stageName": "canary" },
-            { "name": "stage@canary:setup", "stageName": "canary" },
+            { "name": "stage@canary:setup", "stageName": "canary", "virtual": true },
             { "name": "publish", "stageName": "canary" },
             { "name": "docker-publish", "stageName": "canary" },
             { "name": "baz" },
             { "name": "prod-deploy", "stageName": "production" },
-            { "name": "stage@production:setup", "stageName": "production" },
+            { "name": "stage@production:setup", "stageName": "production", "virtual": true },
             { "name": "prod-certify", "stageName": "production" },
             { "name": "post-release" },
-            { "name": "stage@production:teardown", "stageName": "production" },
-            { "name": "stage@canary:teardown", "stageName": "canary" }
+            { "name": "stage@production:teardown", "stageName": "production", "virtual": true },
+            { "name": "stage@canary:teardown", "stageName": "canary", "virtual": true }
         ],
         "edges": [
             { "src": "stage@canary:setup", "dest": "main" },


### PR DESCRIPTION
## Context

With PRs https://github.com/screwdriver-cd/workflow-parser/pull/51 and https://github.com/screwdriver-cd/data-schema/pull/559, a new field `virtual` would be included in the workflow nodes

## Objective

Update tests to expect the new `virtual` field.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
