### PR TITLE
fix(3105): Handle mergeSharedSteps annotation for pipeline template

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,7 @@ const SCHEMA_PIPELINE_TEMPLATE = require('screwdriver-data-schema').config.pipel
 
 const phaseValidateStructure = require('./lib/phase/structural');
 const phaseMerge = require('./lib/phase/merge');
-const {
-    flattenSharedIntoJobs,
-    handleMergeSharedStepsAnnotation,
-    flattenPhase: phaseFlatten
-} = require('./lib/phase/flatten');
+const { flattenSharedIntoJobs, flattenPhase: phaseFlatten } = require('./lib/phase/flatten');
 const phaseValidateFunctionality = require('./lib/phase/functional');
 const phaseGeneratePermutations = require('./lib/phase/permutation');
 
@@ -319,10 +315,11 @@ function parsePipelineYaml({
  * Parses pipeline template configuration
  * @method parsePipelineTemplate
  * @param   {Object}          config
- * @param   {String}          config.yaml           Pipeline Template
- * @return  {Object}                                Pipeline Template
+ * @param   {String}          config.yaml             Pipeline Template
+ * @param   {TemplateFactory} config.templateFactory  Template Factory to get templates
+ * @return  {Object}                                  Pipeline Template
  */
-async function parsePipelineTemplate({ yaml }) {
+async function parsePipelineTemplate({ yaml, templateFactory }) {
     const configToValidate = await parseYaml(yaml);
     const pipelineTemplate = await SCHEMA_PIPELINE_TEMPLATE.validateAsync(configToValidate, {
         abortEarly: false
@@ -332,17 +329,9 @@ async function parsePipelineTemplate({ yaml }) {
     // flatten pipeline template shared setting into jobs
     pipelineTemplateConfig.jobs = flattenSharedIntoJobs(pipelineTemplateConfig.shared, pipelineTemplateConfig.jobs);
 
-    const mergedJobs = {};
+    const { flattenedDoc } = await phaseFlatten(pipelineTemplateConfig, templateFactory);
 
-    // Handle mergeSharedSteps annotation
-    Object.keys(pipelineTemplateConfig.jobs).forEach(j => {
-        mergedJobs[j] = handleMergeSharedStepsAnnotation({
-            sharedConfig: pipelineTemplateConfig.shared,
-            jobConfig: pipelineTemplateConfig.jobs[j]
-        });
-    });
-    delete pipelineTemplateConfig.shared;
-    pipelineTemplateConfig.jobs = mergedJobs;
+    pipelineTemplateConfig.jobs = flattenedDoc.jobs;
 
     return pipelineTemplate;
 }

--- a/index.js
+++ b/index.js
@@ -304,8 +304,7 @@ async function parsePipelineTemplate({ yaml }) {
     Object.keys(pipelineTemplateConfig.jobs).forEach(j => {
         mergedJobs[j] = handleMergeSharedStepsAnnotation({
             sharedConfig: pipelineTemplateConfig.shared,
-            jobConfig: pipelineTemplateConfig.jobs[j],
-            isPipelineTemplate: true
+            jobConfig: pipelineTemplateConfig.jobs[j]
         });
     });
     delete pipelineTemplateConfig.shared;

--- a/index.js
+++ b/index.js
@@ -304,7 +304,8 @@ async function parsePipelineTemplate({ yaml }) {
     Object.keys(pipelineTemplateConfig.jobs).forEach(j => {
         mergedJobs[j] = handleMergeSharedStepsAnnotation({
             sharedConfig: pipelineTemplateConfig.shared,
-            jobConfig: pipelineTemplateConfig.jobs[j]
+            jobConfig: pipelineTemplateConfig.jobs[j],
+            isPipelineTemplate: true
         });
     });
     delete pipelineTemplateConfig.shared;

--- a/index.js
+++ b/index.js
@@ -12,8 +12,11 @@ const SCHEMA_PIPELINE_TEMPLATE = require('screwdriver-data-schema').config.pipel
 
 const phaseValidateStructure = require('./lib/phase/structural');
 const phaseMerge = require('./lib/phase/merge');
-const phaseFlatten = require('./lib/phase/flatten').flattenPhase;
-const flattenSharedIntoJobs = require('./lib/phase/flatten').flattenSharedIntoJobs;
+const {
+    flattenSharedIntoJobs,
+    handleMergeSharedStepsAnnotation,
+    flattenPhase: phaseFlatten
+} = require('./lib/phase/flatten');
 const phaseValidateFunctionality = require('./lib/phase/functional');
 const phaseGeneratePermutations = require('./lib/phase/permutation');
 
@@ -328,7 +331,18 @@ async function parsePipelineTemplate({ yaml }) {
 
     // flatten pipeline template shared setting into jobs
     pipelineTemplateConfig.jobs = flattenSharedIntoJobs(pipelineTemplateConfig.shared, pipelineTemplateConfig.jobs);
+
+    const mergedJobs = {};
+
+    // Handle mergeSharedSteps annotation
+    Object.keys(pipelineTemplateConfig.jobs).forEach(j => {
+        mergedJobs[j] = handleMergeSharedStepsAnnotation({
+            sharedConfig: pipelineTemplateConfig.shared,
+            jobConfig: pipelineTemplateConfig.jobs[j]
+        });
+    });
     delete pipelineTemplateConfig.shared;
+    pipelineTemplateConfig.jobs = mergedJobs;
 
     return pipelineTemplate;
 }

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -283,13 +283,14 @@ function merge(newJob, oldJob, fromTemplate) {
  */
 function flattenSharedIntoJobs(shared, jobs) {
     const newJobs = {};
+    const fieldsToFlatten = ['image', 'matrix', 'steps', 'template', 'description', 'cache', 'parameters', 'provider'];
 
     Object.keys(jobs).forEach(jobName => {
         const newJob = clone(shared);
         const oldJob = clone(jobs[jobName]);
 
         // Replace
-        ['image', 'matrix', 'steps', 'template', 'description', 'cache', 'parameters', 'provider'].forEach(key => {
+        fieldsToFlatten.forEach(key => {
             if (oldJob[key]) {
                 newJob[key] = oldJob[key];
             }
@@ -312,11 +313,24 @@ function flattenSharedIntoJobs(shared, jobs) {
  * @param  {Object} sharedConfig               Shared config
  * @param  {Object} jobConfig                  Job config
  * @param  {Object} [template]                 Template
+ * @param  {Boolean}[isPipelineTemplate]       Flag if is pipeline template
  * @return {Object}                            Merged job config
  */
-function handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig, template }) {
+function handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig, template, isPipelineTemplate }) {
     const sharedSteps = sharedConfig.steps;
     const newJobConfig = jobConfig;
+
+    // Should not add steps if is pipeline template and mergeSharedSteps annotation is set to false (and order keyword is present)
+    if (
+        isPipelineTemplate &&
+        sharedSteps &&
+        !jobConfig.order &&
+        (!jobConfig.annotations || !jobConfig.annotations['screwdriver.cd/mergeSharedSteps'])
+    ) {
+        newJobConfig.steps = [];
+
+        return newJobConfig;
+    }
 
     // merge shared steps into oldJob
     if (

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -307,6 +307,46 @@ function flattenSharedIntoJobs(shared, jobs) {
 }
 
 /**
+ * Merge shared steps into job when mergeSharedSteps annotation is set to true
+ * @param  {Object} sharedConfig               Shared config
+ * @param  {Object} jobConfig                  Job config
+ * @param  {Object} [template]                 Template
+ * @return {Object}                            Merged job config
+ */
+function handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig, template }) {
+    const sharedSteps = sharedConfig.steps;
+    const newJobConfig = jobConfig;
+
+    // merge shared steps into oldJob
+    if (
+        sharedSteps &&
+        ((jobConfig.annotations && jobConfig.annotations['screwdriver.cd/mergeSharedSteps']) ||
+            ((jobConfig.annotations === undefined ||
+                jobConfig.annotations['screwdriver.cd/mergeSharedSteps'] === undefined) &&
+                template &&
+                template.annotations &&
+                template.annotations['screwdriver.cd/mergeSharedSteps']))
+    ) {
+        // convert steps from jobConfig from array to object for faster lookup
+        const jobSteps = jobConfig.steps.reduce((obj, item) => {
+            const key = Object.keys(item)[0];
+
+            obj[key] = item[key];
+
+            return obj;
+        }, {});
+
+        for (let i = 0; i < sharedSteps.length; i += 1) {
+            if (!jobSteps[Object.keys(sharedSteps[i])]) {
+                newJobConfig.steps.push(sharedSteps[i]);
+            }
+        }
+    }
+
+    return newJobConfig;
+}
+
+/**
  * Retrieve template and merge into job config
  *
  * @method mergeTemplateIntoJob
@@ -319,7 +359,7 @@ function flattenSharedIntoJobs(shared, jobs) {
  * @return {Promise}
  */
 function mergeTemplateIntoJob({ jobName, jobConfig, newJobs, templateFactory, sharedConfig, pipelineParameters }) {
-    const oldJob = jobConfig;
+    let oldJob = jobConfig;
 
     // Try to get the template
     return templateFactory.getTemplate(jobConfig.template).then(template => {
@@ -348,29 +388,7 @@ function mergeTemplateIntoJob({ jobName, jobConfig, newJobs, templateFactory, sh
         let warnings = [];
 
         // merge shared steps into oldJob
-        if (
-            sharedConfig.steps &&
-            ((oldJob.annotations && oldJob.annotations['screwdriver.cd/mergeSharedSteps']) ||
-                ((oldJob.annotations === undefined ||
-                    oldJob.annotations['screwdriver.cd/mergeSharedSteps'] === undefined) &&
-                    template.annotations &&
-                    template.annotations['screwdriver.cd/mergeSharedSteps']))
-        ) {
-            // convert steps from oldJob from array to object for faster lookup
-            const oldSteps = oldJob.steps.reduce((obj, item) => {
-                const key = Object.keys(item)[0];
-
-                obj[key] = item[key];
-
-                return obj;
-            }, {});
-
-            for (let i = 0; i < sharedConfig.steps.length; i += 1) {
-                if (!oldSteps[Object.keys(sharedConfig.steps[i])]) {
-                    oldJob.steps.push(sharedConfig.steps[i]);
-                }
-            }
-        }
+        oldJob = handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig: oldJob, template });
 
         // Include parameters from the template only if it not overwritten either in pipeline or job parameters
         if (newJob.parameters !== undefined) {
@@ -728,5 +746,6 @@ function flattenPhase(parsedDoc, templateFactory) {
 
 module.exports = {
     flattenPhase,
-    flattenSharedIntoJobs
+    flattenSharedIntoJobs,
+    handleMergeSharedStepsAnnotation
 };

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -313,24 +313,11 @@ function flattenSharedIntoJobs(shared, jobs) {
  * @param  {Object} sharedConfig               Shared config
  * @param  {Object} jobConfig                  Job config
  * @param  {Object} [template]                 Template
- * @param  {Boolean}[isPipelineTemplate]       Flag if is pipeline template
  * @return {Object}                            Merged job config
  */
-function handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig, template, isPipelineTemplate }) {
+function handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig, template }) {
     const sharedSteps = sharedConfig.steps;
     const newJobConfig = jobConfig;
-
-    // Should not add steps if is pipeline template and mergeSharedSteps annotation is set to false (and order keyword is present)
-    if (
-        isPipelineTemplate &&
-        sharedSteps &&
-        !jobConfig.order &&
-        (!jobConfig.annotations || !jobConfig.annotations['screwdriver.cd/mergeSharedSteps'])
-    ) {
-        newJobConfig.steps = [];
-
-        return newJobConfig;
-    }
 
     // merge shared steps into oldJob
     if (

--- a/test/data/basic-job-with-shared-and-template-override-steps.json
+++ b/test/data/basic-job-with-shared-and-template-override-steps.json
@@ -13,8 +13,39 @@
                     "command": "npm install"
                 },
                 {
-                    "name": "pretest",
-                    "command": "echo pre-test"
+                    "name": "test",
+                    "command": "echo 'my job is overriding this step'"
+                }
+            ],
+            "environment": {
+                "FOO": "from template",
+                "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }],
+        "second": [{
+            "annotations": {
+                "screwdriver.cd/mergeSharedSteps": true
+            },
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
                 },
                 {
                     "name": "test",
@@ -46,11 +77,14 @@
         "nodes": [
             { "name": "~pr" },
             { "name": "~commit" },
-            { "name": "main" }
+            { "name": "main" },
+            { "name": "second" }
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
-            { "src": "~commit", "dest": "main" }
+            { "src": "~commit", "dest": "main" },
+            { "src": "~pr", "dest": "second" },
+            { "src": "~commit", "dest": "second" }
         ]
     },
     "subscribe": {}

--- a/test/data/basic-job-with-shared-and-template-override-steps.yaml
+++ b/test/data/basic-job-with-shared-and-template-override-steps.yaml
@@ -1,6 +1,7 @@
 shared:
+  annotations:
+    screwdriver.cd/mergeSharedSteps: true
   steps:
-    - pretest: echo pre-test
     - predummy: echo 'this step is not merged'
 jobs:
   main:
@@ -12,3 +13,5 @@ jobs:
     requires:
       - ~pr
       - ~commit
+  second:
+    template: mytemplate@1.2.3

--- a/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
+++ b/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
@@ -48,7 +48,11 @@
         "secrets": [],
         "settings": {},
         "sourcePaths": [],
-        "steps": [],
+        "steps": [
+          {
+            "name": "echo \"bang\""
+          }
+        ],
         "template": "sd/noop@1.0.0"
       }
     },

--- a/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
+++ b/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
@@ -1,0 +1,78 @@
+{
+  "config": {
+    "annotations": {
+      "screwdriver.cd/chainPR": false,
+      "screwdriver.cd/restrictPR": "none"
+    },
+    "cache": {
+      "event": [
+        "$SD_SOURCE_DIR/node_modules"
+      ],
+      "pipeline": [
+        "~/node_modules"
+      ]
+    },
+    "jobs": {
+      "extra": {
+        "annotations": {
+          "screwdriver.cd/mergeSharedSteps": true
+        },
+        "environment": {
+          "FOO": "BAR"
+        },
+        "image": "node:20",
+        "requires": [
+          "main"
+        ],
+        "secrets": [],
+        "settings": {},
+        "sourcePaths": [],
+        "steps": [
+          {
+            "name": "echo \"pipeline template test\""
+          }
+        ]
+      },
+      "main": {
+        "annotations": {
+          "screwdriver.cd/mergeSharedSteps": false
+        },
+        "environment": {
+          "FOO": "BAR"
+        },
+        "image": "golang",
+        "requires": [
+          "~pr",
+          "~commit"
+        ],
+        "secrets": [],
+        "settings": {},
+        "sourcePaths": [],
+        "steps": [],
+        "template": "sd/noop@1.0.0"
+      }
+    },
+    "parameters": {
+      "nameA": "value1"
+    },
+    "subscribe": {
+      "scmUrls": [
+        {
+          "https://github.com/VonnyJap/python-zero-to-hero.git": [
+            "~pr"
+          ]
+        },
+        {
+          "https://github.com/VonnyJap/sshca.git": [
+            "~pr"
+          ]
+        }
+      ]
+    }
+  },
+  "description": "An example pipeline template for testing golang files",
+  "maintainer": "foo@bar.com",
+  "name": "example-template",
+  "namespace": "sd-test",
+  "version": "1.0.0"
+}

--- a/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.yaml
+++ b/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.yaml
@@ -1,0 +1,37 @@
+namespace: sd-test
+name: example-template
+version: '1.0.0'
+description: An example pipeline template for testing golang files
+maintainer: foo@bar.com
+config:
+  parameters:
+    nameA: "value1"
+  annotations:
+    screwdriver.cd/restrictPR: none
+    screwdriver.cd/chainPR: false
+  cache:
+     pipeline: [~/node_modules]
+     event: [$SD_SOURCE_DIR/node_modules]
+  subscribe:
+    scmUrls:
+    - https://github.com/VonnyJap/python-zero-to-hero.git: ['~pr']
+    - https://github.com/VonnyJap/sshca.git: ['~pr']
+  shared:
+    image: golang
+    environment:
+      FOO: "BAR"
+    requires: [main]
+    annotations:
+      screwdriver.cd/mergeSharedSteps: true
+    steps:
+      - name: echo "bang"
+  jobs:
+    main:
+      template: sd/noop@1.0.0
+      requires: [~pr, ~commit]
+      annotations:
+        screwdriver.cd/mergeSharedSteps: false
+    extra:
+      image: node:20
+      steps:
+        - name: echo "pipeline template test"

--- a/test/data/parse-pipeline-template-with-shared-setting.json
+++ b/test/data/parse-pipeline-template-with-shared-setting.json
@@ -17,7 +17,6 @@
         "blockedBy": [
           "~main"
         ],
-        "cache": true,
         "description": "This is a description!",
         "annotations": {
           "foo": "a",
@@ -88,7 +87,6 @@
         "blockedBy": [
           "~main"
         ],
-        "cache": true,
         "description": "This is a description!",
         "annotations": {
           "foo": "a",

--- a/test/data/parse-pipeline-template-with-shared-setting.json
+++ b/test/data/parse-pipeline-template-with-shared-setting.json
@@ -7,34 +7,15 @@
   "config": {
     "jobs": {
       "main": {
-        "image": "node:18",
+        "image": "node:20",
         "environment": {
-          "BAR": "foo",
-          "FOO": "foo",
-          "SD_TEMPLATE_FULLNAME": "mytemplate",
-          "SD_TEMPLATE_NAME": "mytemplate",
-          "SD_TEMPLATE_NAMESPACE": "",
-          "SD_TEMPLATE_VERSION": "1.2.3"
+          "FOO": "foo"
         },
         "settings": {
           "email": "foo@example.com"
         },
         "blockedBy": [
           "~main"
-        ],
-        "commands": [
-          {
-            "command": "npm install",
-            "name": "install"
-          },
-          {
-            "command": "npm test",
-            "name": "test"
-          },
-          {
-            "command": "echo $FOO",
-            "name": "echo"
-          }
         ],
         "description": "This is a description!",
         "annotations": {
@@ -45,6 +26,12 @@
           "* * ? * 1",
           "0-59 0-23 * 1 ?"
         ],
+        "matrix": {
+          "NODE_VERSION": [
+            18,
+            20
+          ]
+        },
         "parameters": {
           "color": [
             "red",
@@ -65,18 +52,15 @@
           "region": "us-west-2",
           "role": "arn:aws:iam::111111111111:role/role"
         },
-        "requires": [
-          "~commit"
-        ],
+        "requires": "~commit",
         "secrets": [
-          "GIT_KEY",
           "NPM_TOKEN"
         ],
         "sourcePaths": [
           "src/A",
           "src/AConfig"
         ],
-        "templateId": 7754,
+        "template": "foo/bar@1.0.0",
         "order": [
           "install",
           "test",
@@ -85,45 +69,23 @@
         ],
         "steps": [
           {
-            "install": "npm install"
+            "init": "npm install"
           },
           {
             "test": "npm test"
-          },
-          {
-            "echo": "echo $FOO"
           }
         ]
       },
       "test": {
         "image": "node:18",
         "environment": {
-          "BAR": "foo",
-          "FOO": "foo",
-          "SD_TEMPLATE_FULLNAME": "mytemplate",
-          "SD_TEMPLATE_NAME": "mytemplate",
-          "SD_TEMPLATE_NAMESPACE": "",
-          "SD_TEMPLATE_VERSION": "1.2.3"
+          "FOO": "foo"
         },
         "settings": {
           "email": "foo@example.com"
         },
         "blockedBy": [
           "~main"
-        ],
-        "commands": [
-          {
-            "command": "npm install",
-            "name": "install"
-          },
-          {
-            "command": "npm test",
-            "name": "test"
-          },
-          {
-            "command": "echo $FOO",
-            "name": "echo"
-          }
         ],
         "description": "This is a description!",
         "annotations": {
@@ -134,6 +96,12 @@
           "* * ? * 1",
           "0-59 0-23 * 1 ?"
         ],
+        "matrix": {
+          "NODE_VERSION": [
+            18,
+            20
+          ]
+        },
         "parameters": {
           "color": [
             "red",
@@ -154,18 +122,15 @@
           "region": "us-west-2",
           "role": "arn:aws:iam::111111111111:role/role"
         },
-        "requires": [
-          "~commit"
-        ],
+        "requires": "~commit",
         "secrets": [
-          "GIT_KEY",
           "NPM_TOKEN"
         ],
         "sourcePaths": [
           "src/A",
           "src/AConfig"
         ],
-        "templateId": 7754,
+        "template": "foo/bar@1.0.0",
         "order": [
           "install",
           "test",

--- a/test/data/parse-pipeline-template-with-shared-setting.json
+++ b/test/data/parse-pipeline-template-with-shared-setting.json
@@ -7,15 +7,34 @@
   "config": {
     "jobs": {
       "main": {
-        "image": "node:20",
+        "image": "node:18",
         "environment": {
-          "FOO": "foo"
+          "BAR": "foo",
+          "FOO": "foo",
+          "SD_TEMPLATE_FULLNAME": "mytemplate",
+          "SD_TEMPLATE_NAME": "mytemplate",
+          "SD_TEMPLATE_NAMESPACE": "",
+          "SD_TEMPLATE_VERSION": "1.2.3"
         },
         "settings": {
           "email": "foo@example.com"
         },
         "blockedBy": [
           "~main"
+        ],
+        "commands": [
+          {
+            "command": "npm install",
+            "name": "install"
+          },
+          {
+            "command": "npm test",
+            "name": "test"
+          },
+          {
+            "command": "echo $FOO",
+            "name": "echo"
+          }
         ],
         "description": "This is a description!",
         "annotations": {
@@ -26,12 +45,6 @@
           "* * ? * 1",
           "0-59 0-23 * 1 ?"
         ],
-        "matrix": {
-          "NODE_VERSION": [
-            18,
-            20
-          ]
-        },
         "parameters": {
           "color": [
             "red",
@@ -52,15 +65,18 @@
           "region": "us-west-2",
           "role": "arn:aws:iam::111111111111:role/role"
         },
-        "requires": "~commit",
+        "requires": [
+          "~commit"
+        ],
         "secrets": [
+          "GIT_KEY",
           "NPM_TOKEN"
         ],
         "sourcePaths": [
           "src/A",
           "src/AConfig"
         ],
-        "template": "foo/bar@1.0.0",
+        "templateId": 7754,
         "order": [
           "install",
           "test",
@@ -69,23 +85,45 @@
         ],
         "steps": [
           {
-            "init": "npm install"
+            "install": "npm install"
           },
           {
             "test": "npm test"
+          },
+          {
+            "echo": "echo $FOO"
           }
         ]
       },
       "test": {
         "image": "node:18",
         "environment": {
-          "FOO": "foo"
+          "BAR": "foo",
+          "FOO": "foo",
+          "SD_TEMPLATE_FULLNAME": "mytemplate",
+          "SD_TEMPLATE_NAME": "mytemplate",
+          "SD_TEMPLATE_NAMESPACE": "",
+          "SD_TEMPLATE_VERSION": "1.2.3"
         },
         "settings": {
           "email": "foo@example.com"
         },
         "blockedBy": [
           "~main"
+        ],
+        "commands": [
+          {
+            "command": "npm install",
+            "name": "install"
+          },
+          {
+            "command": "npm test",
+            "name": "test"
+          },
+          {
+            "command": "echo $FOO",
+            "name": "echo"
+          }
         ],
         "description": "This is a description!",
         "annotations": {
@@ -96,12 +134,6 @@
           "* * ? * 1",
           "0-59 0-23 * 1 ?"
         ],
-        "matrix": {
-          "NODE_VERSION": [
-            18,
-            20
-          ]
-        },
         "parameters": {
           "color": [
             "red",
@@ -122,15 +154,18 @@
           "region": "us-west-2",
           "role": "arn:aws:iam::111111111111:role/role"
         },
-        "requires": "~commit",
+        "requires": [
+          "~commit"
+        ],
         "secrets": [
+          "GIT_KEY",
           "NPM_TOKEN"
         ],
         "sourcePaths": [
           "src/A",
           "src/AConfig"
         ],
-        "template": "foo/bar@1.0.0",
+        "templateId": 7754,
         "order": [
           "install",
           "test",

--- a/test/data/parse-pipeline-template-with-shared-setting.yaml
+++ b/test/data/parse-pipeline-template-with-shared-setting.yaml
@@ -11,7 +11,6 @@ config:
     settings:
       email: foo@example.com
     blockedBy: [~main]
-    cache: true
     description: 'This is a description!'
     annotations:
       foo: a

--- a/test/data/pipeline-template-with-mergeSharedSteps-annotation-result.json
+++ b/test/data/pipeline-template-with-mergeSharedSteps-annotation-result.json
@@ -1,0 +1,60 @@
+{
+    "annotations": {},
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "image": "node:20",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "test",
+                    "command": "echo skip"
+                },
+                {
+                    "name": "posttest",
+                    "command": "echo test done"
+                }
+            ],
+            "environment": {
+                "BAR": "foo",
+                "FOO": "user overwrite",
+                "SD_PIPELINE_TEMPLATE_FULLNAME": "foo/bar",
+                "SD_PIPELINE_TEMPLATE_NAME": "bar",
+                "SD_PIPELINE_TEMPLATE_NAMESPACE": "foo",
+                "SD_PIPELINE_TEMPLATE_VERSION": "1.0.0",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+              "GIT_KEY"
+            ],
+            "settings": {
+              "email": "foo@example.com"
+            },
+            "templateId": 7754,
+            "requires": [
+                "~pr",
+                "~commit"
+            ]
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" }
+        ]
+    },
+    "parameters": {},
+    "subscribe": {},
+    "templateVersionId": 111
+}

--- a/test/data/pipeline-template-with-mergeSharedSteps-annotation.json
+++ b/test/data/pipeline-template-with-mergeSharedSteps-annotation.json
@@ -1,0 +1,41 @@
+{
+  "id":111,
+  "version": "1.0.0",
+  "templateId": 1234,
+  "description": "Template for building a NodeJS module\nInstalls dependencies and runs tests\n",
+  "config": {
+    "shared": {
+      "annotations": {
+          "screwdriver.cd/mergeSharedSteps": true
+      },
+      "image": "node:18",
+      "steps": [
+        {
+          "test": "npm test"
+        }
+      ]
+    },
+    "jobs": {
+      "main": {
+        "template": "mytemplate@1.2.3",
+        "requires": ["~pr", "~commit"],
+        "steps": [
+          {
+            "test": "echo skip"
+          },
+          {
+            "posttest": "echo test done"
+          }
+        ]
+      }
+    }
+  },
+  "createTime": "2024-02-08T10:38:51.109Z",
+  "pipelineId": 14,
+  "namespace": "foo",
+  "name": "bar",
+  "maintainer": "test@example.com",
+  "latestVersion": "1.0.6",
+  "updateTime": "2024-02-13T23:26:23.559Z",
+  "templateType": "PIPELINE"
+}

--- a/test/data/pipeline-template-with-mergeSharedSteps-annotation.yaml
+++ b/test/data/pipeline-template-with-mergeSharedSteps-annotation.yaml
@@ -1,0 +1,7 @@
+template: foo/bar@1.0.0
+shared:
+    image: node:20
+    environment:
+        FOO: user overwrite
+    settings:
+        email: foo@example.com

--- a/test/data/pipeline-template-with-user-setting.yaml
+++ b/test/data/pipeline-template-with-user-setting.yaml
@@ -20,3 +20,16 @@ childPipelines:
         - git@github.com:org/userSetting.git
         - https://github.com:org/userSetting2.git
     startAll: true
+stages:
+    canary:
+        requires: baz
+        description: For canary deployment
+        jobs: [main, publish, docker-publish]
+        setup:
+            image: node:18
+            steps:
+                - publish: pre blog
+        teardown:
+            image: node:18
+            steps:
+                - publish: post blog

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1130,6 +1130,15 @@ describe('config parser', () => {
             }).then(data => {
                 assert.deepEqual(data, JSON.parse(loadData('parse-pipeline-template-with-shared-setting.json')));
             }));
+        it('flattens shared setting and handles mergeSharedSteps annotation properly', () =>
+            parsePipelineTemplate({
+                yaml: loadData('parse-pipeline-template-with-mergeSharedSteps-annotation.yaml')
+            }).then(data => {
+                assert.deepEqual(
+                    data,
+                    JSON.parse(loadData('parse-pipeline-template-with-mergeSharedSteps-annotation.json'))
+                );
+            }));
         it('throws error if pipeline template is invalid', () =>
             parsePipelineTemplate({
                 yaml: loadData('parse-pipeline-template-invalid.yaml')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,8 +4,7 @@ const { assert } = require('chai');
 const fs = require('fs');
 const path = require('path');
 const sinon = require('sinon');
-const parser = require('..').parsePipelineYaml;
-const parsePipelineTemplate = require('..').parsePipelineTemplate;
+const { parsePipelineTemplate, parsePipelineYaml: parser } = require('..');
 const pipelineId = 111;
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -21,11 +20,16 @@ function loadData(name) {
 }
 
 describe('config parser', () => {
-    describe('parse pipeline yaml', () => {
-        const templateFactoryMock = {
+    let templateFactoryMock;
+
+    beforeEach(() => {
+        templateFactoryMock = {
             getTemplate: sinon.stub().resolves(JSON.parse(loadData('template.json'))),
             getFullNameAndVersion: sinon.stub().returns({ isVersion: false, isTag: false })
         };
+    });
+
+    describe('parse pipeline yaml', () => {
         const pipelineTemplateVersionFactoryMock = {
             getWithMetadata: sinon.stub().resolves(JSON.parse(loadData('pipeline-template.json')))
         };
@@ -620,6 +624,29 @@ describe('config parser', () => {
                     });
                 });
 
+                it('flattens pipeline template with job template and mergeSharedSteps annotation', () => {
+                    const pipelineTemplateMock = JSON.parse(
+                        loadData('pipeline-template-with-mergeSharedSteps-annotation.json')
+                    );
+
+                    pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(pipelineTemplateMock);
+                    templateFactoryMock.getTemplate.resolves(JSON.parse(loadData('template.json')));
+                    templateFactoryMock.getFullNameAndVersion.returns({ isVersion: true });
+
+                    return parser({
+                        yaml: loadData('pipeline-template-with-mergeSharedSteps-annotation.yaml'),
+                        templateFactory: templateFactoryMock,
+                        triggerFactory,
+                        pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
+                        pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock
+                    }).then(data => {
+                        assert.deepEqual(
+                            data,
+                            JSON.parse(loadData('pipeline-template-with-mergeSharedSteps-annotation-result.json'))
+                        );
+                    });
+                });
+
                 it('flattens pipeline template with user defined pipeline level setting', () => {
                     const pipelineTemplateMock = JSON.parse(loadData('pipeline-template-with-user-setting.json'));
 
@@ -1072,13 +1099,15 @@ describe('config parser', () => {
     describe('parse pipeline template', () => {
         it('flattens shared setting into jobs', () =>
             parsePipelineTemplate({
-                yaml: loadData('parse-pipeline-template-with-shared-setting.yaml')
+                yaml: loadData('parse-pipeline-template-with-shared-setting.yaml'),
+                templateFactory: templateFactoryMock
             }).then(data => {
                 assert.deepEqual(data, JSON.parse(loadData('parse-pipeline-template-with-shared-setting.json')));
             }));
         it('throws error if pipeline template is invalid', () =>
             parsePipelineTemplate({
-                yaml: loadData('parse-pipeline-template-invalid.yaml')
+                yaml: loadData('parse-pipeline-template-invalid.yaml'),
+                templateFactory: templateFactoryMock
             }).then(assert.fail, err => {
                 assert.match(err.toString(), /[ValidationError]: "config.jobs" is required/);
             }));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1099,15 +1099,13 @@ describe('config parser', () => {
     describe('parse pipeline template', () => {
         it('flattens shared setting into jobs', () =>
             parsePipelineTemplate({
-                yaml: loadData('parse-pipeline-template-with-shared-setting.yaml'),
-                templateFactory: templateFactoryMock
+                yaml: loadData('parse-pipeline-template-with-shared-setting.yaml')
             }).then(data => {
                 assert.deepEqual(data, JSON.parse(loadData('parse-pipeline-template-with-shared-setting.json')));
             }));
         it('throws error if pipeline template is invalid', () =>
             parsePipelineTemplate({
-                yaml: loadData('parse-pipeline-template-invalid.yaml'),
-                templateFactory: templateFactoryMock
+                yaml: loadData('parse-pipeline-template-invalid.yaml')
             }).then(assert.fail, err => {
                 assert.match(err.toString(), /[ValidationError]: "config.jobs" is required/);
             }));


### PR DESCRIPTION
## Context

Would be nice if the pipeline template could use job templates and `mergeSharedSteps` annotation.

## Objective

This PR allows pipeline template to use job template and `mergeSharedSteps` annotation.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3105

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
