### PR TITLE
feat(3102): parser to return an error if a job within a stage is triggered by jobs that are not within the same stage

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,6 @@ function parsePipelineYaml({
                 const res = {
                     annotations: Hoek.reach(doc, 'annotations', { default: {} }),
                     jobs,
-                    stages: Hoek.reach(doc, 'stages', { default: {} }),
                     childPipelines: Hoek.reach(doc, 'childPipelines', { default: {} }),
                     workflowGraph: Hoek.reach(doc, 'workflowGraph'),
                     parameters: Hoek.reach(doc, 'parameters'),
@@ -233,6 +232,12 @@ function parsePipelineYaml({
 
                 if (Hoek.deepEqual(res.childPipelines, {})) {
                     delete res.childPipelines;
+                }
+
+                const stages = Hoek.reach(doc, 'stages', { default: {} });
+
+                if (!Hoek.deepEqual(stages, {})) {
+                    res.stages = stages;
                 }
 
                 const templateVersionId = Hoek.reach(doc, 'templateVersionId');

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -302,8 +302,8 @@ function validateStages(stages, jobs) {
         }
         stage.jobs.forEach(jobName => {
             if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {
-                throw new YamlParser.YAMLException(
-                    `${jobName} job has invalid requires: ${jobs[jobName].requires}, triggers must be in the same stage`
+                errors.push(
+                    `${jobName} job has invalid requires: ${jobs[jobName].requires}. This job belongs to the stage {stageName} and is allowed only to have other jobs of the same stage in requires.`
                 );
             }
         });

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -296,6 +296,7 @@ function validateStages(stages, jobs) {
     Object.entries(stages).forEach(([stageName, stage]) => {
         const jobsInStage = [...stage.jobs];
         // Check if setup job is not in the list, then add it
+
         if (!jobsInStage.includes(`stage@${stageName}:setup`)) {
             jobsInStage.push(`stage@${stageName}:setup`);
         }

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -307,7 +307,7 @@ function validateStages(stages, jobs) {
             if (jobs[jobName] && jobs[jobName].requires) {
                 if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {
                     errors.push(
-                        `${jobName} job has invalid requires: ${jobs[jobName].requires}. Triggers have to be jobs in ${stageName} stage.`
+                        `${jobName} job has invalid requires: ${jobs[jobName].requires}. Triggers must be jobs from  ${stageName} stage.`
                     );
                 }
             }

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -273,8 +273,6 @@ function validateStages(stages, jobs) {
         return errors;
     }
 
-    console.log('stages:', stages);
-    console.log('jobs:', jobs);
     // Get list of job names in jobs
     const jobNames = Object.keys(jobs);
 

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -283,7 +283,7 @@ function validateStages(stages, jobs) {
     const duplicateJobsInStage = stageJobNames.filter((item, index) => stageJobNames.indexOf(item) !== index);
 
     if (duplicateJobsInStage.length > 0) {
-        throw new YamlParser.YAMLException(`Cannot have duplicate job in multiple stages: ${duplicateJobsInStage}`);
+        errors.push(`Cannot have duplicate job in multiple stages: ${duplicateJobsInStage}`);
     }
 
     // If job name does not exist, throw error

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -278,7 +278,7 @@ function verifyStages(stages, jobs) {
     Object.values(stages).forEach(stage => {
         stageJobNames = stageJobNames.concat(stage.jobs);
     });
-    console.log(stageJobNames);
+
     // If job name is repeated in stages, throw error
     const duplicateJobsInStage = stageJobNames.filter((item, index) => stageJobNames.indexOf(item) !== index);
 
@@ -297,7 +297,7 @@ function verifyStages(stages, jobs) {
         if (!stages[stageName].jobs || stages[stageName].jobs.length === 0) {
             throw new YamlParser.YAMLException(`Cannot have stage ${stageName} without jobs`);
         }
-        const jobsInStage = stages[stageName].jobs;
+        const jobsInStage = [...stages[stageName].jobs];
         // Check if setup job is not in the list, then add it
 
         if (!jobsInStage.includes(`stage@${stageName}:setup`)) {

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -302,6 +302,7 @@ function validateStages(stages, jobs) {
         if (!jobsInStage.includes(`stage@${stageName}:setup`)) {
             jobsInStage.push(`stage@${stageName}:setup`);
         }
+        // Make sure requires jobs are all stage jobs
         stage.jobs.forEach(jobName => {
             if (jobs[jobName] && jobs[jobName].requires) {
                 if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -299,7 +299,6 @@ function validateStages(stages, jobs) {
     Object.entries(stages).forEach(([stageName, stage]) => {
         const jobsInStage = [...stage.jobs];
         // Check if setup job is not in the list, then add it
-
         if (!jobsInStage.includes(`stage@${stageName}:setup`)) {
             jobsInStage.push(`stage@${stageName}:setup`);
         }

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -298,6 +298,7 @@ function validateStages(stages, jobs) {
 
     Object.entries(stages).forEach(([stageName, stage]) => {
         const jobsInStage = [...stage.jobs];
+
         // Check if setup job is not in the list, then add it
         if (!jobsInStage.includes(`stage@${stageName}:setup`)) {
             jobsInStage.push(`stage@${stageName}:setup`);
@@ -307,7 +308,7 @@ function validateStages(stages, jobs) {
             if (jobs[jobName] && jobs[jobName].requires) {
                 if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {
                     errors.push(
-                        `${jobName} job has invalid requires: ${jobs[jobName].requires}. Triggers must be jobs from  ${stageName} stage.`
+                        `${jobName} job has invalid requires: ${jobs[jobName].requires}. Triggers must be jobs from ${stageName} stage.`
                     );
                 }
             }

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -264,7 +264,7 @@ function validateWorkflowGraph(doc) {
  * @param  {Object} stages Stages
  * @param  {Object} jobs   Jobs
  */
-function verifyStages(stages, jobs) {
+function validateStages(stages, jobs) {
     if (!stages) {
         return;
     }

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -293,7 +293,7 @@ function verifyStages(stages, jobs) {
         throw new YamlParser.YAMLException(`Cannot have nonexistent job in stages: ${nonexistentJobsInStage}`);
     }
 
-    Object.keys(stages).forEach(stageName => {
+    Object.entries(stages).forEach(([stageName, stage])=> {
         const jobsInStage = [...stages[stageName].jobs];
         // Check if setup job is not in the list, then add it
 

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -6,6 +6,7 @@ const clone = require('clone');
 const WorkflowParser = require('screwdriver-workflow-parser');
 const SlackValidation = require('screwdriver-notifications-slack');
 const EmailValidation = require('screwdriver-notifications-email');
+const YamlParser = require('js-yaml');
 
 // Actual environment size is limited by space, not quantity.
 // We do this to force sd.yaml to be simpler.
@@ -89,6 +90,26 @@ function validateBuildClusterAnnotation(doc, buildClusterFactory) {
     }
 
     return Promise.resolve([]);
+}
+
+/**
+ * Ensure the triggers for a job are valid
+ * @method isJobTriggersValid
+ * @param  {Array}  triggers    List of requires configured for a job
+ * @param  {Array}  options     List of valid options to trigger a job
+ * @return {Boolean}
+ *
+ */
+function isJobTriggersValid(triggers, options) {
+    // it is valid if triggers is not defined or empty
+    if (!triggers || triggers.length === 0) {
+        return true;
+    }
+
+    // remove tilde from triggers
+    const noTildeTriggers = triggers.map(item => item.replace(/^~/, ''));
+
+    return noTildeTriggers.every(item => options.includes(item));
 }
 
 /**
@@ -238,6 +259,61 @@ function validateWorkflowGraph(doc) {
 }
 
 /**
+ * Check there are no duplicate jobs in stages and all jobs listed exist
+ * @method verifyStages
+ * @param  {Object} stages Stages
+ * @param  {Object} jobs   Jobs
+ */
+function verifyStages(stages, jobs) {
+    if (!stages) {
+        return;
+    }
+
+    // Get list of job names in jobs
+    const jobNames = Object.keys(jobs);
+
+    // Get list of job names in stages
+    let stageJobNames = [];
+
+    Object.values(stages).forEach(stage => {
+        stageJobNames = stageJobNames.concat(stage.jobs);
+    });
+    console.log(stageJobNames);
+    // If job name is repeated in stages, throw error
+    const duplicateJobsInStage = stageJobNames.filter((item, index) => stageJobNames.indexOf(item) !== index);
+
+    if (duplicateJobsInStage.length > 0) {
+        throw new YamlParser.YAMLException(`Cannot have duplicate job in multiple stages: ${duplicateJobsInStage}`);
+    }
+
+    // If job name does not exist, throw error
+    const nonexistentJobsInStage = stageJobNames.filter(jobName => !jobNames.includes(jobName));
+
+    if (nonexistentJobsInStage.length > 0) {
+        throw new YamlParser.YAMLException(`Cannot have nonexistent job in stages: ${nonexistentJobsInStage}`);
+    }
+
+    Object.keys(stages).forEach(stageName => {
+        if (!stages[stageName].jobs || stages[stageName].jobs.length === 0) {
+            throw new YamlParser.YAMLException(`Cannot have stage ${stageName} without jobs`);
+        }
+        const jobsInStage = stages[stageName].jobs;
+        // Check if setup job is not in the list, then add it
+
+        if (!jobsInStage.includes(`stage@${stageName}:setup`)) {
+            jobsInStage.push(`stage@${stageName}:setup`);
+        }
+        stages[stageName].jobs.forEach(jobName => {
+            if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {
+                throw new YamlParser.YAMLException(
+                    `${jobName} job has invalid requires: ${jobs[jobName].requires}, triggers must be in the same stage`
+                );
+            }
+        });
+    });
+}
+
+/**
  * Functional Phase
  *
  * Now that we have a constant list of jobs, this phase is for validating that the
@@ -266,6 +342,12 @@ module.exports = async ({
 
     // Jobs
     errors = errors.concat(validateJobSchema(doc));
+
+    try {
+        verifyStages(doc.stages, doc.jobs);
+    } catch (error) {
+        errors.push(error);
+    }
 
     // Workflow graph
     doc.workflowGraph = await generateWorkflowGraph(doc, triggerFactory, pipelineId);

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -308,6 +308,8 @@ function validateStages(stages, jobs) {
             }
         });
     });
+    
+    return errors;
 }
 
 /**

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -6,7 +6,6 @@ const clone = require('clone');
 const WorkflowParser = require('screwdriver-workflow-parser');
 const SlackValidation = require('screwdriver-notifications-slack');
 const EmailValidation = require('screwdriver-notifications-email');
-// const YamlParser = require('js-yaml');
 
 // Actual environment size is limited by space, not quantity.
 // We do this to force sd.yaml to be simpler.

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -294,9 +294,6 @@ function verifyStages(stages, jobs) {
     }
 
     Object.keys(stages).forEach(stageName => {
-        if (!stages[stageName].jobs || stages[stageName].jobs.length === 0) {
-            throw new YamlParser.YAMLException(`Cannot have stage ${stageName} without jobs`);
-        }
         const jobsInStage = [...stages[stageName].jobs];
         // Check if setup job is not in the list, then add it
 

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -260,7 +260,7 @@ function validateWorkflowGraph(doc) {
 
 /**
  * Check there are no duplicate jobs in stages and all jobs listed exist
- * @method verifyStages
+ * @method validateStages
  * @param  {Object} stages Stages
  * @param  {Object} jobs   Jobs
  */
@@ -293,14 +293,13 @@ function validateStages(stages, jobs) {
         throw new YamlParser.YAMLException(`Cannot have nonexistent job in stages: ${nonexistentJobsInStage}`);
     }
 
-    Object.entries(stages).forEach(([stageName, stage])=> {
-        const jobsInStage = [...stages[stageName].jobs];
+    Object.entries(stages).forEach(([stageName, stage]) => {
+        const jobsInStage = [...stage.jobs];
         // Check if setup job is not in the list, then add it
-
         if (!jobsInStage.includes(`stage@${stageName}:setup`)) {
             jobsInStage.push(`stage@${stageName}:setup`);
         }
-        stages[stageName].jobs.forEach(jobName => {
+        stage.jobs.forEach(jobName => {
             if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {
                 throw new YamlParser.YAMLException(
                     `${jobName} job has invalid requires: ${jobs[jobName].requires}, triggers must be in the same stage`
@@ -341,7 +340,7 @@ module.exports = async ({
     errors = errors.concat(validateJobSchema(doc));
 
     try {
-        verifyStages(doc.stages, doc.jobs);
+        validateStages(doc.stages, doc.jobs);
     } catch (error) {
         errors.push(error);
     }

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -261,8 +261,8 @@ function validateWorkflowGraph(doc) {
 /**
  * Check there are no duplicate jobs in stages and all jobs listed exist
  * @method validateStages
- * @param  {Object} stages Stages
- * @param  {Object} jobs   Jobs
+ * @param  {Object} stages Map of stage name to stage definition
+ * @param  {Object} jobs     Map of job name to job configuration
  */
 function validateStages(stages, jobs) {
     if (!stages) {

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -6,7 +6,7 @@ const clone = require('clone');
 const WorkflowParser = require('screwdriver-workflow-parser');
 const SlackValidation = require('screwdriver-notifications-slack');
 const EmailValidation = require('screwdriver-notifications-email');
-const YamlParser = require('js-yaml');
+// const YamlParser = require('js-yaml');
 
 // Actual environment size is limited by space, not quantity.
 // We do this to force sd.yaml to be simpler.
@@ -261,14 +261,20 @@ function validateWorkflowGraph(doc) {
 /**
  * Check there are no duplicate jobs in stages and all jobs listed exist
  * @method validateStages
- * @param  {Object} stages Map of stage name to stage definition
- * @param  {Object} jobs     Map of job name to job configuration
+ * @param  {Object} stages  Map of stage name to stage definition
+ * @param  {Object} jobs    Map of job name to job configuration
+ * @return {Array}          List of errors
  */
 function validateStages(stages, jobs) {
+    // init list to store all the errors
+    const errors = [];
+
     if (!stages) {
-        return;
+        return errors;
     }
 
+    console.log('stages:', stages);
+    console.log('jobs:', jobs);
     // Get list of job names in jobs
     const jobNames = Object.keys(jobs);
 
@@ -301,14 +307,16 @@ function validateStages(stages, jobs) {
             jobsInStage.push(`stage@${stageName}:setup`);
         }
         stage.jobs.forEach(jobName => {
-            if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {
-                errors.push(
-                    `${jobName} job has invalid requires: ${jobs[jobName].requires}. This job belongs to the stage {stageName} and is allowed only to have other jobs of the same stage in requires.`
-                );
+            if (jobs[jobName] && jobs[jobName].requires) {
+                if (!isJobTriggersValid(jobs[jobName].requires, jobsInStage)) {
+                    errors.push(
+                        `${jobName} job has invalid requires: ${jobs[jobName].requires}. Triggers have to be jobs in ${stageName} stage.`
+                    );
+                }
             }
         });
     });
-    
+
     return errors;
 }
 
@@ -341,12 +349,8 @@ module.exports = async ({
 
     // Jobs
     errors = errors.concat(validateJobSchema(doc));
-
-    try {
-        validateStages(doc.stages, doc.jobs);
-    } catch (error) {
-        errors.push(error);
-    }
+    // Stages
+    errors = errors.concat(validateStages(doc.stages, doc.jobs));
 
     // Workflow graph
     doc.workflowGraph = await generateWorkflowGraph(doc, triggerFactory, pipelineId);

--- a/lib/phase/functional.js
+++ b/lib/phase/functional.js
@@ -290,7 +290,7 @@ function validateStages(stages, jobs) {
     const nonexistentJobsInStage = stageJobNames.filter(jobName => !jobNames.includes(jobName));
 
     if (nonexistentJobsInStage.length > 0) {
-        throw new YamlParser.YAMLException(`Cannot have nonexistent job in stages: ${nonexistentJobsInStage}`);
+        errors.push(`Cannot have nonexistent job in stages: ${nonexistentJobsInStage}`);
     }
 
     Object.entries(stages).forEach(([stageName, stage]) => {

--- a/test/data/pipeline-with-stages-and-invalid-triggers.yaml
+++ b/test/data/pipeline-with-stages-and-invalid-triggers.yaml
@@ -1,0 +1,43 @@
+stages:
+    canary:
+        requires: baz
+        description: For canary deployment
+        jobs: [ main, publish, docker-publish ]
+    production:
+        requires: ~stage@canary
+        description: For production deployment
+        jobs: [ prod-deploy, prod-certify ]
+
+shared:
+    image: node:4
+jobs:
+    main:
+        steps:
+            -   install: npm install
+            -   test: npm test
+            -   publish: npm publish
+        requires: [ baz ]
+    publish:
+        steps:
+            -   echo-hello: echo hello
+        requires: [ main ]
+    docker-publish:
+        steps:
+            -   echo-docker: echo docker
+        requires: publish
+    baz:
+        requires: ~commit
+        steps:
+            -   echo-world: echo world
+    prod-deploy:
+        requires: [ ]
+        steps:
+            -   echo: echo production deployment
+    prod-certify:
+        requires: [ prod-deploy ]
+        steps:
+            -   echo: echo production certify
+    post-release:
+        requires: [ ~stage@production ]
+        steps:
+            -   echo: stage downstream job

--- a/test/data/pipeline-with-stages-and-invalid-triggers.yaml
+++ b/test/data/pipeline-with-stages-and-invalid-triggers.yaml
@@ -2,7 +2,7 @@ stages:
     canary:
         requires: baz
         description: For canary deployment
-        jobs: [ main, publish, docker-publish ]
+        jobs: [ main, publish, docker-publish, boom ]
     production:
         requires: ~stage@canary
         description: For production deployment
@@ -29,6 +29,8 @@ jobs:
         requires: ~commit
         steps:
             -   echo-world: echo world
+    boom:
+        template: "JobTestNamespace/jobrequirestemplate@2"
     prod-deploy:
         requires: [ ]
         steps:

--- a/test/data/pipeline-with-stages-and-teardown-job-explicit.json
+++ b/test/data/pipeline-with-stages-and-teardown-job-explicit.json
@@ -42,9 +42,7 @@
         "environment": {},
         "image": "node:20",
         "requires": [
-          "~acceptance-tests",
-          "~promotion-230899",
-          "~promotion-1010409"
+          "~stage@testing:setup"
         ],
         "secrets": [],
         "settings": {},
@@ -70,9 +68,7 @@
         "environment": {},
         "image": "node:20",
         "requires": [
-          "~acceptance-tests",
-          "~promotion-230899",
-          "~promotion-1010409"
+          "~stage@testing:setup"
         ],
         "secrets": [],
         "settings": {},
@@ -98,9 +94,7 @@
         "environment": {},
         "image": "node:20",
         "requires": [
-          "~acceptance-tests",
-          "~promotion-230899",
-          "~promotion-1010409"
+          "~stage@testing:setup"
         ],
         "secrets": [],
         "settings": {},
@@ -259,39 +253,15 @@
       },
       {
         "dest": "frontend",
-        "src": "acceptance-tests"
-      },
-      {
-        "dest": "frontend",
-        "src": "promotion-230899"
-      },
-      {
-        "dest": "frontend",
-        "src": "promotion-1010409"
+        "src": "stage@testing:setup"
       },
       {
         "dest": "backend",
-        "src": "acceptance-tests"
-      },
-      {
-        "dest": "backend",
-        "src": "promotion-230899"
-      },
-      {
-        "dest": "backend",
-        "src": "promotion-1010409"
+        "src": "stage@testing:setup"
       },
       {
         "dest": "mtls-app",
-        "src": "acceptance-tests"
-      },
-      {
-        "dest": "mtls-app",
-        "src": "promotion-230899"
-      },
-      {
-        "dest": "mtls-app",
-        "src": "promotion-1010409"
+        "src": "stage@testing:setup"
       },
       {
         "dest": "test",
@@ -350,6 +320,11 @@
         "stageName": "testing"
       },
       {
+        "name": "stage@testing:setup",
+        "stageName": "testing",
+        "virtual": true
+      },
+      {
         "name": "backend",
         "stageName": "testing"
       },
@@ -360,11 +335,6 @@
       {
         "name": "test",
         "stageName": "testing"
-      },
-      {
-        "name": "stage@testing:setup",
-        "stageName": "testing",
-        "virtual": true
       },
       {
         "name": "stage@testing:teardown",

--- a/test/data/pipeline-with-stages-and-teardown-job-explicit.yaml
+++ b/test/data/pipeline-with-stages-and-teardown-job-explicit.yaml
@@ -14,15 +14,15 @@ jobs:
   promotion-1010409:
     blockedBy: [ ~acceptance-tests ]
   frontend:
-    requires: [ ~acceptance-tests, ~promotion-230899, ~promotion-1010409 ]
+    requires: []
     blockedBy:
       - ~test
   backend:
-    requires: [ ~acceptance-tests, ~promotion-230899, ~promotion-1010409 ]
+    requires: []
     blockedBy:
       - ~test
   mtls-app:
-    requires: [ ~acceptance-tests, ~promotion-230899, ~promotion-1010409 ]
+    requires: []
     blockedBy:
       - ~test
 

--- a/test/data/templateWithRequires.json
+++ b/test/data/templateWithRequires.json
@@ -1,0 +1,29 @@
+{
+    "id": 7754,
+    "name": "mytemplate",
+    "version": "1.2.3",
+    "description": "test template",
+    "maintainer": "bar@foo.com",
+    "labels": [],
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "install": "npm install" },
+            { "test": "npm test" }
+        ],
+        "environment": {
+            "FOO": "from template",
+            "BAR": "foo"
+        },
+        "secrets": [
+            "GIT_KEY"
+        ],
+        "settings": {
+            "email": "foo@example.com"
+        },
+        "requires": [
+            "~pr",
+            "~commit"
+        ]
+    }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const sinon = require('sinon');
 const parser = require('..').parsePipelineYaml;
-const parsePipelineTemplate = require('..').parsePipelineTemplate;
+const { parsePipelineTemplate } = require('..');
 const pipelineId = 111;
 
 sinon.assert.expose(assert, { prefix: '' });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -236,10 +236,7 @@ describe('config parser', () => {
                         pipelineId,
                         templateFactory: templateFactoryMock
                     }).then(data => {
-                        assert.match(
-                            data.errors[0],
-                            /YAMLException: Cannot have duplicate job in multiple stages: main/
-                        );
+                        assert.match(data.errors[0], /Error: Cannot have duplicate job in multiple stages: main\n/);
                     }));
 
                 it('returns an error if nonexistent job in stages', () =>
@@ -249,10 +246,7 @@ describe('config parser', () => {
                         triggerFactory,
                         pipelineId
                     }).then(data => {
-                        assert.match(
-                            data.errors[0],
-                            /YAMLException: Cannot have nonexistent job in stages: publish,deploy/
-                        );
+                        assert.match(data.errors[0], /Error: Cannot have nonexistent job in stages: publish,deploy\n/);
                     }));
 
                 it('returns an error if a job within a stage is triggered by jobs that are not within the same stage', () =>
@@ -262,9 +256,11 @@ describe('config parser', () => {
                         triggerFactory,
                         pipelineId
                     }).then(data => {
+                        console.log(data);
+                        console.log(data.errors);
                         assert.match(
                             data.errors[0],
-                            /YAMLException: main job has invalid requires: baz, triggers must be in the same stage/
+                            /Error: main job has invalid requires: baz. Triggers have to be jobs in canary stage./
                         );
                     }));
             });
@@ -356,6 +352,7 @@ describe('config parser', () => {
                 let lockedStepsTemplate;
                 let jobParametersTemplate;
                 let providerTemplate;
+                let jobWithRequiresTemplate;
 
                 beforeEach(() => {
                     firstTemplate = JSON.parse(loadData('template.json'));
@@ -367,6 +364,7 @@ describe('config parser', () => {
                     lockedStepsTemplate = JSON.parse(loadData('templateWithLockedSteps.json'));
                     jobParametersTemplate = JSON.parse(loadData('templateWithParameters.json'));
                     providerTemplate = JSON.parse(loadData('templateWithProvider.json'));
+                    jobWithRequiresTemplate = JSON.parse(loadData('templateWithRequires.json'));
                     templateFactoryMock.getFullNameAndVersion.returns({ isVersion: true });
                     templateFactoryMock.getTemplate.withArgs('mytemplate@1.2.3').resolves(firstTemplate);
                     templateFactoryMock.getTemplate.withArgs('yourtemplate@2').resolves(secondTemplate);
@@ -384,6 +382,9 @@ describe('config parser', () => {
                     templateFactoryMock.getTemplate
                         .withArgs('JobProviderTestNamespace/jobprovidertemplate@2')
                         .resolves(providerTemplate);
+                    templateFactoryMock.getTemplate
+                        .withArgs('JobTestNamespace/jobrequirestemplate@2')
+                        .resolves(jobWithRequiresTemplate);
                 });
 
                 it('flattens templates successfully', () =>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -260,7 +260,7 @@ describe('config parser', () => {
                         console.log(data.errors);
                         assert.match(
                             data.errors[0],
-                            /Error: main job has invalid requires: baz. Triggers have to be jobs in canary stage./
+                            /Error: main job has invalid requires: baz. Triggers must be jobs from canary stage./
                         );
                     }));
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -254,6 +254,19 @@ describe('config parser', () => {
                             /YAMLException: Cannot have nonexistent job in stages: publish,deploy/
                         );
                     }));
+
+                it('returns an error if a job within a stage is triggered by jobs that are not within the same stage', () =>
+                    parser({
+                        yaml: loadData('pipeline-with-stages-and-invalid-triggers.yaml'),
+                        templateFactory: templateFactoryMock,
+                        triggerFactory,
+                        pipelineId
+                    }).then(data => {
+                        assert.match(
+                            data.errors[0],
+                            /YAMLException: main job has invalid requires: baz, triggers must be in the same stage/
+                        );
+                    }));
             });
 
             describe('subscribe', () => {


### PR DESCRIPTION
## Context

Jobs within a stage can only be triggered by either a setup job within the same stage or by other jobs also located within that stage

## Objective

This change enforces the restriction described above. Consequently, it will generate an error message if violated.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3102

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
