### PR TITLE
fix: Remove stage setup from stage teardown requires

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -5,6 +5,7 @@ const clone = require('clone');
 const { STAGE_TRIGGER } = require('screwdriver-data-schema/config/regex');
 
 const STAGE_PREFIX = 'stage@';
+const STAGE_SETUP_TEARDOWN_PATTERN = /stage@[\w-]+:(?:setup|teardown)$/;
 const DEFAULT_JOB = {
     image: 'node:18',
     steps: [{ noop: 'echo noop' }],
@@ -566,7 +567,11 @@ function getTeardownRequires(jobs, stageName) {
     // Find jobs that belong to the stage
     // Get requires for jobs that belong to the stage
     Object.keys(jobs).forEach(jobName => {
-        if (jobs[jobName].stage && jobs[jobName].stage.name === stageName) {
+        if (
+            jobs[jobName].stage &&
+            jobs[jobName].stage.name === stageName &&
+            !STAGE_SETUP_TEARDOWN_PATTERN.test(jobName)
+        ) {
             if (Array.isArray(jobs[jobName].requires)) {
                 stageJobsRequires = stageJobsRequires.concat(jobs[jobName].requires);
             } else {
@@ -658,6 +663,7 @@ function flattenStageSetupAndTeardownJobs(doc) {
                 ...stageTeardown,
                 ...{ requires: getTeardownRequires(newJobs, stageName), stage: { name: stageName } }
             };
+
             delete stages[stageName].teardown;
             delete stages[stageName].setup;
         });

--- a/test/data/pipeline-with-stages-and-teardown-job-explicit.json
+++ b/test/data/pipeline-with-stages-and-teardown-job-explicit.json
@@ -1,0 +1,375 @@
+{
+  "annotations": {},
+  "jobs": {
+    "acceptance-tests": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "blockedBy": [
+          "~promotion-230899"
+        ],
+        "commands": [
+          {
+            "command": "echo hi",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "requires": [
+          "~commit",
+          "~tag:/.*-alpha$/"
+        ],
+        "secrets": [],
+        "settings": {}
+      }
+    ],
+    "backend": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "blockedBy": [
+          "~test"
+        ],
+        "commands": [
+          {
+            "command": "echo hi",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "requires": [
+          "~acceptance-tests",
+          "~promotion-230899",
+          "~promotion-1010409"
+        ],
+        "secrets": [],
+        "settings": {},
+        "stage": {
+          "name": "testing"
+        }
+      }
+    ],
+    "frontend": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "blockedBy": [
+          "~test"
+        ],
+        "commands": [
+          {
+            "command": "echo hi",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "requires": [
+          "~acceptance-tests",
+          "~promotion-230899",
+          "~promotion-1010409"
+        ],
+        "secrets": [],
+        "settings": {},
+        "stage": {
+          "name": "testing"
+        }
+      }
+    ],
+    "mtls-app": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "blockedBy": [
+          "~test"
+        ],
+        "commands": [
+          {
+            "command": "echo hi",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "requires": [
+          "~acceptance-tests",
+          "~promotion-230899",
+          "~promotion-1010409"
+        ],
+        "secrets": [],
+        "settings": {},
+        "stage": {
+          "name": "testing"
+        }
+      }
+    ],
+    "promotion-1010409": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "blockedBy": [
+          "~acceptance-tests"
+        ],
+        "commands": [
+          {
+            "command": "echo hi",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "secrets": [],
+        "settings": {}
+      }
+    ],
+    "promotion-230899": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "blockedBy": [
+          "~acceptance-tests"
+        ],
+        "commands": [
+          {
+            "command": "echo hi",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "secrets": [],
+        "settings": {}
+      }
+    ],
+    "stage@testing:setup": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false,
+          "screwdriver.cd/virtualJob": true
+        },
+        "commands": [
+          {
+            "command": "echo noop",
+            "name": "noop"
+          }
+        ],
+        "environment": {},
+        "image": "node:18",
+        "requires": [
+          "~acceptance-tests",
+          "~promotion-230899",
+          "~promotion-1010409"
+        ],
+        "secrets": [],
+        "settings": {},
+        "stage": {
+          "name": "testing"
+        }
+      }
+    ],
+    "stage@testing:teardown": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "commands": [
+          {
+            "command": "echo teardown",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "requires": [
+          "test"
+        ],
+        "secrets": [],
+        "settings": {},
+        "stage": {
+          "name": "testing"
+        }
+      }
+    ],
+    "test": [
+      {
+        "annotations": {
+          "screwdriver.cd/collapseBuilds": false
+        },
+        "blockedBy": [
+          "~frontend",
+          "~backend",
+          "~mtls-app"
+        ],
+        "commands": [
+          {
+            "command": "echo hi",
+            "name": "echo"
+          }
+        ],
+        "environment": {},
+        "image": "node:20",
+        "requires": [
+          "frontend",
+          "backend",
+          "mtls-app"
+        ],
+        "secrets": [],
+        "settings": {},
+        "stage": {
+          "name": "testing"
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "stages": {
+    "testing": {
+      "description": "Teardown test resources after completion.",
+      "jobs": [
+        "backend",
+        "frontend",
+        "mtls-app",
+        "test"
+      ],
+      "requires": [
+        "~acceptance-tests",
+        "~promotion-230899",
+        "~promotion-1010409"
+      ]
+    }
+  },
+  "subscribe": {},
+  "workflowGraph": {
+    "edges": [
+      {
+        "dest": "acceptance-tests",
+        "src": "~commit"
+      },
+      {
+        "dest": "acceptance-tests",
+        "src": "~tag:/.*-alpha$/"
+      },
+      {
+        "dest": "frontend",
+        "src": "acceptance-tests"
+      },
+      {
+        "dest": "frontend",
+        "src": "promotion-230899"
+      },
+      {
+        "dest": "frontend",
+        "src": "promotion-1010409"
+      },
+      {
+        "dest": "backend",
+        "src": "acceptance-tests"
+      },
+      {
+        "dest": "backend",
+        "src": "promotion-230899"
+      },
+      {
+        "dest": "backend",
+        "src": "promotion-1010409"
+      },
+      {
+        "dest": "mtls-app",
+        "src": "acceptance-tests"
+      },
+      {
+        "dest": "mtls-app",
+        "src": "promotion-230899"
+      },
+      {
+        "dest": "mtls-app",
+        "src": "promotion-1010409"
+      },
+      {
+        "dest": "test",
+        "join": true,
+        "src": "frontend"
+      },
+      {
+        "dest": "test",
+        "join": true,
+        "src": "backend"
+      },
+      {
+        "dest": "test",
+        "join": true,
+        "src": "mtls-app"
+      },
+      {
+        "dest": "stage@testing:setup",
+        "src": "acceptance-tests"
+      },
+      {
+        "dest": "stage@testing:setup",
+        "src": "promotion-230899"
+      },
+      {
+        "dest": "stage@testing:setup",
+        "src": "promotion-1010409"
+      },
+      {
+        "dest": "stage@testing:teardown",
+        "join": true,
+        "src": "test"
+      }
+    ],
+    "nodes": [
+      {
+        "name": "~pr"
+      },
+      {
+        "name": "~commit"
+      },
+      {
+        "name": "acceptance-tests"
+      },
+      {
+        "name": "~tag:/.*-alpha$/"
+      },
+      {
+        "name": "promotion-230899"
+      },
+      {
+        "name": "promotion-1010409"
+      },
+      {
+        "name": "frontend",
+        "stageName": "testing"
+      },
+      {
+        "name": "backend",
+        "stageName": "testing"
+      },
+      {
+        "name": "mtls-app",
+        "stageName": "testing"
+      },
+      {
+        "name": "test",
+        "stageName": "testing"
+      },
+      {
+        "name": "stage@testing:setup",
+        "stageName": "testing",
+        "virtual": true
+      },
+      {
+        "name": "stage@testing:teardown",
+        "stageName": "testing"
+      }
+    ]
+  }
+}

--- a/test/data/pipeline-with-stages-and-teardown-job-explicit.yaml
+++ b/test/data/pipeline-with-stages-and-teardown-job-explicit.yaml
@@ -1,0 +1,46 @@
+shared:
+  image: node:20
+  steps:
+    - echo: echo hi
+  annotations:
+    screwdriver.cd/collapseBuilds: false
+
+jobs:
+  acceptance-tests:
+    requires: [ ~commit, ~tag:/.*-alpha$/ ]
+    blockedBy: [ ~promotion-230899 ]
+  promotion-230899:
+    blockedBy: [ ~acceptance-tests ]
+  promotion-1010409:
+    blockedBy: [ ~acceptance-tests ]
+  frontend:
+    requires: [ ~acceptance-tests, ~promotion-230899, ~promotion-1010409 ]
+    blockedBy:
+      - ~test
+  backend:
+    requires: [ ~acceptance-tests, ~promotion-230899, ~promotion-1010409 ]
+    blockedBy:
+      - ~test
+  mtls-app:
+    requires: [ ~acceptance-tests, ~promotion-230899, ~promotion-1010409 ]
+    blockedBy:
+      - ~test
+
+  test:
+    requires:
+      - frontend
+      - backend
+      - mtls-app
+    blockedBy:
+      - ~frontend
+      - ~backend
+      - ~mtls-app
+
+stages:
+  testing:
+    jobs: [ backend, frontend, mtls-app, test ]
+    requires: [ ~acceptance-tests, ~promotion-230899, ~promotion-1010409 ]
+    description: "Teardown test resources after completion."
+    teardown:
+      steps:
+        - echo: echo teardown

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,6 +195,19 @@ describe('config parser', () => {
                         );
                     }));
 
+                it('returns a yaml with stages in correct format when setup and teardown jobs are explicitly defined', () =>
+                    parser({
+                        yaml: loadData('pipeline-with-stages-and-teardown-job-explicit.yaml'),
+                        templateFactory: templateFactoryMock,
+                        triggerFactory,
+                        pipelineId
+                    }).then(data => {
+                        assert.deepEqual(
+                            data,
+                            JSON.parse(loadData('pipeline-with-stages-and-teardown-job-explicit.json'))
+                        );
+                    }));
+
                 it('returns a yaml with stages in correct format when setup and teardown jobs are implicitly created', () =>
                     parser({
                         yaml: loadData('pipeline-with-stages-and-setup-teardown-jobs-implicit.yaml'),


### PR DESCRIPTION
## Context

When users explicitly define a stage teardown, the teardown just is getting the wrong `requires` definition.

sd.yaml
```
...
stages:
  canary:
    jobs: [ test ]
    requires: [ ~acceptance-tests ]
    teardown:
      steps:
        - echo: echo teardown
```

result before:
```
jobs:
  stage@canary:teardown:
    requires: [ stage@canary:setup, test ]
    steps:
      - echo: echo teardown
...
```
## Objective

This PR prevents adding stage setup job to stage teardown `requires`.

result after:
```
jobs:
  stage@canary:teardown:
    requires: [ test ]
    steps:
      - echo: echo teardown
...
```
## References
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
