### PR TITLE
fix(3105): Should delete mergeSharedSteps annotation after flattening for pipeline template yaml

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,6 +306,7 @@ async function parsePipelineTemplate({ yaml }) {
             sharedConfig: pipelineTemplateConfig.shared,
             jobConfig: pipelineTemplateConfig.jobs[j]
         });
+        delete mergedJobs[j].annotations['screwdriver.cd/mergeSharedSteps'];
     });
     delete pipelineTemplateConfig.shared;
     pipelineTemplateConfig.jobs = mergedJobs;

--- a/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
+++ b/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
@@ -14,9 +14,7 @@
     },
     "jobs": {
       "extra": {
-        "annotations": {
-          "screwdriver.cd/mergeSharedSteps": true
-        },
+        "annotations": {},
         "environment": {
           "FOO": "BAR"
         },
@@ -34,9 +32,7 @@
         ]
       },
       "main": {
-        "annotations": {
-          "screwdriver.cd/mergeSharedSteps": false
-        },
+        "annotations": {},
         "environment": {
           "FOO": "BAR"
         },


### PR DESCRIPTION
## Context

Should remove mergeSharedSteps annotation after flattening shared for pipeline template yaml.

## Objective

This PR removes mergeSharedSteps annotation after flattening shared for pipeline template yaml.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3105

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
