### PR TITLE
fix: Pull in latest data-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^23.1.0",
+    "screwdriver-data-schema": "^23.3.1",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
     "screwdriver-workflow-parser": "^4.3.0",


### PR DESCRIPTION
## Objective

This PR pulls in latest data-schema changes:
- https://github.com/screwdriver-cd/data-schema/pull/566 
- https://github.com/screwdriver-cd/data-schema/pull/565

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
