### PR TITLE
feat(3106): Allow some customized job fields for pipeline template

### DIFF
--- a/lib/phase/merge.js
+++ b/lib/phase/merge.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Hoek = require('@hapi/hoek');
+const clone = require('clone');
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE =
     require('screwdriver-data-schema').config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
 
@@ -59,6 +60,91 @@ function isEmpty(value) {
 }
 
 /**
+ * Merge user job with pipeline template job config
+ * @param  {Object} parsedDoc                     Parsed screwdriver yaml
+ * @param  {Object} newPipeline                   Pipeline template config
+ * @param  {Object} pipelineTemplate              Pipeline template
+ * @return {Object}                  Pipeline template config with merged job
+ */
+function handlePipelineTemplateMergeForJobs(parsedDoc, newPipeline, pipelineTemplate) {
+    // Check if job names are valid
+    if (parsedDoc.jobs) {
+        const pipelineTemplateJobNames = Object.keys(newPipeline.jobs);
+        const invalidJobNames = [];
+
+        Object.keys(parsedDoc.jobs).forEach(jobName => {
+            if (!pipelineTemplateJobNames.includes(jobName)) {
+                invalidJobNames.push(jobName);
+            }
+        });
+
+        if (invalidJobNames.length > 0) {
+            throw new Error(
+                `User template has job name(s) that do not exist in pipeline template ${parsedDoc.template}: ${invalidJobNames}`
+            );
+        }
+
+        // Flatten jobs
+        const fieldsToFlatten = ['image', 'requires'];
+
+        Object.keys(parsedDoc.jobs).forEach(jobName => {
+            const newJob = clone(pipelineTemplate.config.jobs[jobName]);
+            const oldJob = clone(parsedDoc.jobs[jobName]);
+
+            // Replace
+            fieldsToFlatten.forEach(key => {
+                if (oldJob[key]) {
+                    newJob[key] = oldJob[key];
+                }
+            });
+
+            // Merge job environment
+            if (oldJob.environment || newJob.environment) {
+                newJob.environment = {
+                    ...newJob.environment,
+                    ...oldJob.environment
+                };
+            }
+
+            // Replace settings
+            const yamlSettingsConfig = oldJob.settings || {};
+            const templateSettingsConfig = newJob.settings || {};
+            const newSlackSettings = yamlSettingsConfig.slack || {};
+            const oldSlackSettings = templateSettingsConfig.slack || {};
+            const newEmailSettings = yamlSettingsConfig.email || {};
+            const oldEmailSettings = templateSettingsConfig.email || {};
+
+            newJob.settings = {
+                ...templateSettingsConfig,
+                ...yamlSettingsConfig
+            };
+            if (!isEmpty(oldSlackSettings)) {
+                newJob.settings = {
+                    ...newJob.settings,
+                    slack: {
+                        ...oldSlackSettings,
+                        ...newSlackSettings
+                    }
+                };
+            }
+            if (!isEmpty(oldEmailSettings)) {
+                newJob.settings = {
+                    ...newJob.settings,
+                    email: {
+                        ...oldEmailSettings,
+                        ...newEmailSettings
+                    }
+                };
+            }
+
+            newPipeline.jobs[jobName] = newJob;
+        });
+    }
+
+    return newPipeline;
+}
+
+/**
  * Merge parsed yaml config with pipeline template config
  * Pipeline yaml will take precedence over pipeline template
  * @method mergePipelineLevelConfig
@@ -68,7 +154,10 @@ function isEmpty(value) {
  * @return  {Object}                               Yaml with merged pipeline level settings
  */
 function mergePipelineLevelConfig(parsedDoc, pipelineTemplate) {
-    const newPipeline = pipelineTemplate.config;
+    let newPipeline = pipelineTemplate.config;
+
+    // Handle jobs config
+    newPipeline = handlePipelineTemplateMergeForJobs(parsedDoc, newPipeline, pipelineTemplate);
 
     // merge cache config
     const yamlCacheConfig = parsedDoc.cache || {};

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^23.3.1",
+    "screwdriver-data-schema": "^23.3.2",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
     "screwdriver-workflow-parser": "^4.3.0",

--- a/test/data/pipeline-template-invalid-job-names.yaml
+++ b/test/data/pipeline-template-invalid-job-names.yaml
@@ -1,0 +1,11 @@
+template: foo/bar@1.0.0
+jobs:
+    main:
+        image: node:18
+        requires:
+            - ~pr
+            - ~commit
+    extra:
+        requires: []
+    other:
+        requires: []

--- a/test/data/pipeline-template-with-new-customized-job-result.json
+++ b/test/data/pipeline-template-with-new-customized-job-result.json
@@ -1,0 +1,142 @@
+{
+    "annotations": {
+        "bar": "template setting",
+        "screwdriver.cd/restrictPR": "fork"
+    },
+    "childPipelines": {
+        "scmUrls": [
+            "git@github.com:org/templateSetting.git",
+            "https://github.com:org/templateSetting2.git"
+        ],
+        "startAll": true
+    },
+    "parameters": {
+        "arr": [
+            "a",
+            "b"
+        ],
+        "common": {
+            "description": "template description",
+            "value": "template setting"
+        },
+        "foo": "template setting",
+        "override": "template setting"
+    },
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "cache": {
+                "pipeline": [
+                    "~/templateSetting/pipeline"
+                ],
+                "event": [
+                    "$SD_SOURCE_DIR/templateSetting/event"
+                ],
+                "job": [
+                    "/temp/templateSetting/job/main"
+                ]
+            },
+            "image": "node:25",
+            "commands": [
+                {
+                    "name": "init",
+                    "command": "npm install"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                }
+            ],
+            "environment": {
+                "BAR": "baz",
+                "FOO": "foo",
+                "SD_PIPELINE_TEMPLATE_FULLNAME": "foo/bar",
+                "SD_PIPELINE_TEMPLATE_NAME": "bar",
+                "SD_PIPELINE_TEMPLATE_NAMESPACE": "foo",
+                "SD_PIPELINE_TEMPLATE_VERSION": "1.0.0"
+            },
+            "secrets": [
+                "NPM_TOKEN"
+            ],
+            "settings": {
+                "slack": [
+                    "room_a"
+                ]
+            },
+            "requires": []
+        }],
+        "job1": [{
+            "annotations": {},
+            "cache": {
+                "pipeline": [
+                    "~/templateSetting/pipeline"
+                ],
+                "event": [
+                    "$SD_SOURCE_DIR/templateSetting/event"
+                ],
+                "job": []
+            },
+            "image": "node:10",
+            "commands": [
+                {
+                    "name": "init",
+                    "command": "npm install"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                }
+            ],
+            "environment": {
+                "OTHER": "foo",
+                "BAR": "bar",
+                "FOO": "foo",
+                "SD_PIPELINE_TEMPLATE_FULLNAME": "foo/bar",
+                "SD_PIPELINE_TEMPLATE_NAME": "bar",
+                "SD_PIPELINE_TEMPLATE_NAMESPACE": "foo",
+                "SD_PIPELINE_TEMPLATE_VERSION": "1.0.0"
+            },
+            "secrets": [
+                "NPM_TOKEN"
+            ],
+            "settings": {
+                "slack": [
+                    "room_b"
+                ]
+            },
+            "requires": [
+                "main"
+            ]
+        }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "job1" }
+        ],
+        "edges": [
+            { "src": "main", "dest": "job1", "join": true }
+        ]
+    },
+    "subscribe": {
+        "scmUrls": [
+            {
+                "git@github.com:foo/templateSetting.git#master": [
+                    "~commit",
+                    "~tags",
+                    "~release"
+                ]
+            },
+            {
+                "git@github.com:foo/commonSetting.git#master": [
+                  "~commit",
+                  "~tags",
+                  "~release"
+                ]
+            }
+        ]
+    },
+    "templateVersionId": 111
+}

--- a/test/data/pipeline-template-with-new-customized-job.yaml
+++ b/test/data/pipeline-template-with-new-customized-job.yaml
@@ -1,0 +1,17 @@
+template: foo/bar@1.0.0
+jobs:
+    main:
+        image: node:25
+        settings:
+            slack: [room_a]
+        environment:
+            BAR: baz
+        requires: []
+    job1:
+        image: node:10
+        settings:
+            slack: [room_b]
+        environment:
+            OTHER: foo
+        requires: [main]
+  


### PR DESCRIPTION
## Context

At present, users utilizing a pipeline template are restricted from making any modifications within the job configuration.
## Objective

This PR merges user job customizations for image, settings, environment, and requires within `job` field when using pipeline template. Also adds validation to make sure user job names match pipeline template job names.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3106

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
