### PR TITLE
fix: pull latest data-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^23.3.2",
+    "screwdriver-data-schema": "^23.5.1",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
     "screwdriver-workflow-parser": "^4.3.0",


### PR DESCRIPTION
## Context

Latest data schema allows `workflowGraph` for pipeline template /versions endpoint.

## Objective

This PR pulls in latest packages.

## References
Related to https://github.com/screwdriver-cd/data-schema/pull/571

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
