### PR TITLE
fix: add workflowgraph when parsing pipeline template

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,23 +334,10 @@ async function parsePipelineTemplate({ yaml }) {
 async function validatePipelineTemplate({ yaml, templateFactory }) {
     const pipelineTemplate = await parsePipelineTemplate({ yaml });
 
-    console.log('pipelineTemplate.config: ', pipelineTemplate.config);
-    console.log('templateFactory: ', templateFactory);
-
     // Merge template steps for validator
     const { newJobs } = await flattenTemplates(pipelineTemplate.config, templateFactory, true);
 
-    console.log('newJobs: ', newJobs);
-
     pipelineTemplate.config.jobs = newJobs;
-
-    // // Add workflowGraph
-    // const { doc } = await phaseValidateFunctionality({
-    //     flattenedDoc: pipelineTemplate.config,
-    //     isPipelineTemplate: true
-    // });
-
-    // pipelineTemplate.config = doc;
 
     return pipelineTemplate;
 }

--- a/index.js
+++ b/index.js
@@ -312,6 +312,14 @@ async function parsePipelineTemplate({ yaml }) {
     delete pipelineTemplateConfig.shared;
     pipelineTemplateConfig.jobs = mergedJobs;
 
+    // Add workflowGraph
+    const { doc } = await phaseValidateFunctionality({
+        flattenedDoc: pipelineTemplateConfig,
+        isPipelineTemplate: true
+    });
+
+    pipelineTemplate.config = doc;
+
     return pipelineTemplate;
 }
 

--- a/index.js
+++ b/index.js
@@ -333,18 +333,24 @@ async function parsePipelineTemplate({ yaml }) {
  */
 async function validatePipelineTemplate({ yaml, templateFactory }) {
     const pipelineTemplate = await parsePipelineTemplate({ yaml });
+
+    console.log('pipelineTemplate.config: ', pipelineTemplate.config);
+    console.log('templateFactory: ', templateFactory);
+
     // Merge template steps for validator
     const { newJobs } = await flattenTemplates(pipelineTemplate.config, templateFactory, true);
 
+    console.log('newJobs: ', newJobs);
+
     pipelineTemplate.config.jobs = newJobs;
 
-    // Add workflowGraph
-    const { doc } = await phaseValidateFunctionality({
-        flattenedDoc: pipelineTemplate.config,
-        isPipelineTemplate: true
-    });
+    // // Add workflowGraph
+    // const { doc } = await phaseValidateFunctionality({
+    //     flattenedDoc: pipelineTemplate.config,
+    //     isPipelineTemplate: true
+    // });
 
-    pipelineTemplate.config = doc;
+    // pipelineTemplate.config = doc;
 
     return pipelineTemplate;
 }

--- a/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
+++ b/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
@@ -68,7 +68,38 @@
           ]
         }
       ]
-    }
+    },
+    "workflowGraph": {
+      "edges": [
+        {
+          "dest": "main",
+          "src": "~pr"
+        },
+        {
+          "dest": "main",
+          "src": "~commit"
+        },
+        {
+          "dest": "extra",
+          "join": true,
+          "src": "main"
+        }
+      ],
+      "nodes": [
+        {
+          "name": "~pr"
+        },
+        {
+          "name": "~commit"
+        },
+        {
+          "name": "main"
+        },
+        {
+          "name": "extra"
+        }
+      ]
+    }   
   },
   "description": "An example pipeline template for testing golang files",
   "maintainer": "foo@bar.com",

--- a/test/data/parse-pipeline-template-with-shared-setting.json
+++ b/test/data/parse-pipeline-template-with-shared-setting.json
@@ -155,6 +155,32 @@
         "value": "sd-bot",
         "description": "User running build"
       }
+    },
+    "workflowGraph": {
+      "edges": [
+        {
+          "dest": "main",
+          "src": "~commit"
+        },
+        {
+          "dest": "test",
+          "src": "~commit"
+        }
+      ],
+      "nodes": [
+        {
+          "name": "~pr"
+        },
+        {
+          "name": "~commit"
+        },
+        {
+          "name": "main"
+        },
+        {
+          "name": "test"
+        }
+      ]
     }
   }
 }

--- a/test/data/validate-pipeline-template-with-job-template.json
+++ b/test/data/validate-pipeline-template-with-job-template.json
@@ -106,12 +106,12 @@
     "workflowGraph": {
       "edges": [
         {
-          "dest": "extra",
+          "dest": "main",
           "join": true,
           "src": "main"
         },
         {
-          "dest": "main",
+          "dest": "extra",
           "join": true,
           "src": "main"
         },
@@ -129,10 +129,10 @@
           "name": "~commit"
         },
         {
-          "name": "extra"
+          "name": "main"
         },
         {
-          "name": "main"
+          "name": "extra"
         },
         {
           "name": "other"


### PR DESCRIPTION
## Context

Workflow graph is not generated when parsing the pipeline template. 

## Objective

Generates the workflow graph when parsing the pipeline template. 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
