### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,6 +318,8 @@ async function parsePipelineTemplate({ yaml }) {
         isPipelineTemplate: true
     });
 
+    pipelineTemplate.workflowGraph = doc.workflowGraph;
+    delete doc.workflowGraph;
     pipelineTemplate.config = doc;
 
     return pipelineTemplate;

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
     "keymbinatorial": "^2.0.0",
-    "screwdriver-data-schema": "^23.5.1",
+    "screwdriver-data-schema": "^24.0.0",
     "screwdriver-notifications-email": "^3.0.1",
     "screwdriver-notifications-slack": "^5.0.0",
-    "screwdriver-workflow-parser": "^4.3.0",
+    "screwdriver-workflow-parser": "^5.0.0",
     "shell-escape": "^0.2.0",
     "tinytim": "^0.1.1"
   }

--- a/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
+++ b/test/data/parse-pipeline-template-with-mergeSharedSteps-annotation.json
@@ -68,38 +68,38 @@
           ]
         }
       ]
-    },
-    "workflowGraph": {
-      "edges": [
-        {
-          "dest": "main",
-          "src": "~pr"
-        },
-        {
-          "dest": "main",
-          "src": "~commit"
-        },
-        {
-          "dest": "extra",
-          "join": true,
-          "src": "main"
-        }
-      ],
-      "nodes": [
-        {
-          "name": "~pr"
-        },
-        {
-          "name": "~commit"
-        },
-        {
-          "name": "main"
-        },
-        {
-          "name": "extra"
-        }
-      ]
-    }   
+    }
+  },
+  "workflowGraph": {
+    "edges": [
+      {
+        "dest": "main",
+        "src": "~pr"
+      },
+      {
+        "dest": "main",
+        "src": "~commit"
+      },
+      {
+        "dest": "extra",
+        "join": true,
+        "src": "main"
+      }
+    ],
+    "nodes": [
+      {
+        "name": "~pr"
+      },
+      {
+        "name": "~commit"
+      },
+      {
+        "name": "main"
+      },
+      {
+        "name": "extra"
+      }
+    ]
   },
   "description": "An example pipeline template for testing golang files",
   "maintainer": "foo@bar.com",

--- a/test/data/parse-pipeline-template-with-shared-setting.json
+++ b/test/data/parse-pipeline-template-with-shared-setting.json
@@ -155,32 +155,32 @@
         "value": "sd-bot",
         "description": "User running build"
       }
-    },
-    "workflowGraph": {
-      "edges": [
-        {
-          "dest": "main",
-          "src": "~commit"
-        },
-        {
-          "dest": "test",
-          "src": "~commit"
-        }
-      ],
-      "nodes": [
-        {
-          "name": "~pr"
-        },
-        {
-          "name": "~commit"
-        },
-        {
-          "name": "main"
-        },
-        {
-          "name": "test"
-        }
-      ]
     }
+  },
+  "workflowGraph": {
+    "edges": [
+      {
+        "dest": "main",
+        "src": "~commit"
+      },
+      {
+        "dest": "test",
+        "src": "~commit"
+      }
+    ],
+    "nodes": [
+      {
+        "name": "~pr"
+      },
+      {
+        "name": "~commit"
+      },
+      {
+        "name": "main"
+      },
+      {
+        "name": "test"
+      }
+    ]
   }
 }

--- a/test/data/validate-pipeline-template-with-job-template.json
+++ b/test/data/validate-pipeline-template-with-job-template.json
@@ -102,43 +102,43 @@
           ]
         }
       ]
-    },
-    "workflowGraph": {
-      "edges": [
-        {
-          "dest": "main",
-          "join": true,
-          "src": "main"
-        },
-        {
-          "dest": "extra",
-          "join": true,
-          "src": "main"
-        },
-        {
-          "dest": "other",
-          "join": true,
-          "src": "main"
-        }
-      ],
-      "nodes": [
-        {
-          "name": "~pr"
-        },
-        {
-          "name": "~commit"
-        },
-        {
-          "name": "main"
-        },
-        {
-          "name": "extra"
-        },
-        {
-          "name": "other"
-        }
-      ]
     }
+  },
+  "workflowGraph": {
+    "edges": [
+      {
+        "dest": "main",
+        "join": true,
+        "src": "main"
+      },
+      {
+        "dest": "extra",
+        "join": true,
+        "src": "main"
+      },
+      {
+        "dest": "other",
+        "join": true,
+        "src": "main"
+      }
+    ],
+    "nodes": [
+      {
+        "name": "~pr"
+      },
+      {
+        "name": "~commit"
+      },
+      {
+        "name": "main"
+      },
+      {
+        "name": "extra"
+      },
+      {
+        "name": "other"
+      }
+    ]
   },
   "description": "An example pipeline template for testing golang files",
   "maintainer": "foo@bar.com",


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

Changes were made in https://github.com/screwdriver-cd/data-schema/pull/571 (and related PRs) to store `workflowGraph` of pipeline template as part of the `config` 

## Objective

Move `workflowGraph` out of `config` and keep it at the same level as `config`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
