### PR TITLE
feat(3106): Allow job annotation field for pipeline template

### DIFF
--- a/lib/phase/merge.js
+++ b/lib/phase/merge.js
@@ -4,7 +4,7 @@ const Hoek = require('@hapi/hoek');
 const clone = require('clone');
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE =
     require('screwdriver-data-schema').config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
-const ALLOWED_JOB_FIELDS_WITH_PIPELINE_TEMPLATE = ['settings', 'requires', 'image', 'environment'];
+const ALLOWED_JOB_FIELDS_WITH_PIPELINE_TEMPLATE = ['settings', 'requires', 'image', 'environment', 'annotations'];
 const { merge } = require('./flatten');
 
 /**
@@ -106,6 +106,14 @@ function handlePipelineTemplateMergeForJobs(parsedDoc, newPipeline, pipelineTemp
                     newJob.environment = {
                         ...newJob.environment,
                         ...oldJob.environment
+                    };
+                }
+
+                // Merge job annotations
+                if (oldJob.annotations || newJob.annotations) {
+                    newJob.annotations = {
+                        ...newJob.annotations,
+                        ...oldJob.annotations
                     };
                 }
 

--- a/test/data/pipeline-template-with-customized-job-result.json
+++ b/test/data/pipeline-template-with-customized-job-result.json
@@ -24,7 +24,9 @@
     },
     "jobs": {
         "main": [{
-            "annotations": {},
+            "annotations": {
+                "screwdriver.cd/cpu": "MICRO"
+            },
             "cache": {
                 "pipeline": [
                     "~/templateSetting/pipeline"
@@ -66,7 +68,16 @@
             "requires": []
         }],
         "job1": [{
-            "annotations": {},
+            "annotations": {
+                "screwdriver.cd/buildCluster": "test-cluster",
+                "testAnnotation": {
+                    "array": ["bar", "baz"],
+                    "obj": {
+                        "text": "this is a test field",
+                        "boolean": false
+                    }
+                }
+            },
             "cache": {
                 "pipeline": [
                     "~/templateSetting/pipeline"

--- a/test/data/pipeline-template-with-customized-job.yaml
+++ b/test/data/pipeline-template-with-customized-job.yaml
@@ -13,5 +13,11 @@ jobs:
             slack: [room_b]
         environment:
             OTHER: foo
+        annotations:
+            testAnnotation:
+                array: [ bar, baz ]
+                obj:
+                    text: this is a test field
+                    boolean: false
+            screwdriver.cd/buildCluster: test-cluster
         requires: [main]
-  

--- a/test/data/pipeline-template-with-new-customized-job-result.json
+++ b/test/data/pipeline-template-with-new-customized-job-result.json
@@ -24,7 +24,10 @@
     },
     "jobs": {
         "main": [{
-            "annotations": {},
+            "annotations": {
+                "screwdriver.cd/cpu": "TURBO",
+                "screwdriver.cd/buildCluster": "test-cluster"
+            },
             "cache": {
                 "pipeline": [
                     "~/templateSetting/pipeline"
@@ -66,7 +69,12 @@
             "requires": []
         }],
         "job1": [{
-            "annotations": {},
+            "annotations": {
+                "screwdriver.cd/buildCluster": "initial-cluster",
+                "testAnnotation": {
+                    "testKey": "This is a test field"
+                }
+            },
             "cache": {
                 "pipeline": [
                     "~/templateSetting/pipeline"
@@ -104,7 +112,9 @@
             ]
         }],
         "job2": [{
-            "annotations": {},
+            "annotations": {
+                "other": "bar"
+            },
             "cache": {
                 "pipeline": [
                     "~/templateSetting/pipeline"

--- a/test/data/pipeline-template-with-new-customized-job.yaml
+++ b/test/data/pipeline-template-with-new-customized-job.yaml
@@ -6,12 +6,16 @@ jobs:
             slack: [room_a]
         environment:
             BAR: baz
+        annotations:
+            screwdriver.cd/buildCluster: test-cluster
+            screwdriver.cd/cpu: TURBO
         requires: []
     job2:
         image: node:10
         environment:
             OTHER: foo
+        annotations:
+            other: bar
         requires: [main]
         steps:
             - echo: echo new step
-  

--- a/test/data/pipeline-template-with-pipeline-setting-result.json
+++ b/test/data/pipeline-template-with-pipeline-setting-result.json
@@ -26,7 +26,9 @@
     },
     "jobs": {
         "main": [{
-            "annotations": {},
+            "annotations": {
+                "screwdriver.cd/cpu": "MICRO"
+            },
             "cache": {
                 "pipeline": [
                     "~/userSetting/pipeline"
@@ -67,7 +69,12 @@
             ]
         }],
         "job1": [{
-            "annotations": {},
+            "annotations": {
+                "screwdriver.cd/buildCluster": "initial-cluster",
+                "testAnnotation": {
+                    "testKey": "This is a test field"
+                }
+            },
             "cache": {
                 "pipeline": [
                     "~/userSetting/pipeline"

--- a/test/data/pipeline-template-with-template-setting-result.json
+++ b/test/data/pipeline-template-with-template-setting-result.json
@@ -25,7 +25,9 @@
   "jobs": {
     "main": [
       {
-        "annotations": {},
+        "annotations": {
+          "screwdriver.cd/cpu": "MICRO"
+        },
         "cache": {
           "pipeline": [
             "~/templateSetting/pipeline"
@@ -67,7 +69,12 @@
       }
     ],
     "job1": [{
-      "annotations": {},
+      "annotations": {
+        "screwdriver.cd/buildCluster": "initial-cluster",
+        "testAnnotation": {
+          "testKey": "This is a test field"
+        }
+      },
       "cache": {
           "pipeline": [
               "~/templateSetting/pipeline"

--- a/test/data/pipeline-template-with-template-setting.json
+++ b/test/data/pipeline-template-with-template-setting.json
@@ -23,6 +23,9 @@
           "FOO": "foo",
           "BAR": "bar"
         },
+        "annotations": {
+          "screwdriver.cd/cpu": "MICRO"
+        },
         "secrets": [
           "NPM_TOKEN"
         ]
@@ -43,6 +46,12 @@
         "environment": {
           "FOO": "foo",
           "BAR": "bar"
+        },
+        "annotations": {
+          "screwdriver.cd/buildCluster": "initial-cluster",
+          "testAnnotation": {
+            "testKey": "This is a test field"
+          }
         },
         "secrets": [
           "NPM_TOKEN"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -774,7 +774,7 @@ describe('config parser', () => {
                     }).then(data => {
                         assert.deepEqual(
                             data.errors[0],
-                            'Error: Job "main" has unsupported fields in user yaml. Can only set settings,requires,image,environment.'
+                            'Error: Job "main" has unsupported fields in user yaml. Can only set settings,requires,image,environment,annotations.'
                         );
                     }));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Users can customize `settings`, `image`, `environment` ... fields.
However, they cannot make modifications for the `annotations` field.

Some users want to change `annotation` fields such as needing more build resource or changing periodic time.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR allows users to overwrite `annotation` within `job` field when using pipeline template.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Related to https://github.com/screwdriver-cd/screwdriver/issues/3106

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
