### PR TITLE
fix(2330): Workflow graph has difference between the pipeline page and the validator page

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -455,8 +455,9 @@ async function flattenTemplates(doc, templateFactory, isPipelineTemplate) {
     const newJobs = {};
     const templates = [];
     const { jobs, shared, parameters } = doc;
+    const jobNames = Object.keys(jobs);
 
-    Object.keys(jobs).forEach(jobName => {
+    jobNames.forEach(jobName => {
         const jobConfig = clone(jobs[jobName]);
         const templateConfig = jobConfig.template;
         const order = jobConfig.order || [];
@@ -488,7 +489,19 @@ async function flattenTemplates(doc, templateFactory, isPipelineTemplate) {
     });
 
     // Wait until all promises are resolved
-    return Promise.all(templates).then(warnings => ({ warnings: [].concat(...warnings), newJobs }));
+    // Inserting newJobs with template is delayed, hence the order of newJobs.keys is incompatible to doc.jobs.keys
+    return Promise.all(templates).then(warnings => {
+        const sortedNewJobs = {};
+
+        jobNames.forEach(jobName => {
+            sortedNewJobs[jobName] = newJobs[jobName];
+        });
+
+        return {
+            warnings: [].concat(...warnings),
+            newJobs: sortedNewJobs
+        };
+    });
 }
 
 /**

--- a/test/data/basic-job-with-images.json
+++ b/test/data/basic-job-with-images.json
@@ -59,10 +59,10 @@
         "name": "~commit"
       },
       {
-        "name": "publish"
+        "name": "main"
       },
       {
-        "name": "main"
+        "name": "publish"
       }
     ]
   },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The following workflow has a difference between the pipeline page and validator page.
Furthermore the workflow graph is changed when comment out the template of `A` on the validator page.

```yaml
shared:
    image: node:12
jobs:
    A:
        requires: [~pr, B]
        template: nodejs/test@latest
        steps:
            - runA
    B:
        requires: [~pr, ~commit]
        steps:
            - runB
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Make the workflow graph be unique.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue comment https://github.com/screwdriver-cd/screwdriver/issues/2330#issuecomment-1085447477

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
