### PR TITLE
feat(#11529): throw err if using admin annotation in yaml

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,10 @@ function validateReservedAnnotation(doc) {
                 default: {}
             });
 
+            if (Object.keys(jobAnnotations).some(key => key.startsWith('screwdriver.cd/admin'))) {
+                throw new Error('Annotations starting with screwdriver.cd/admin are reserved for system use only');
+            }
+
             warnings = warnings.concat(
                 Object.keys(jobAnnotations)
                     .filter(key => {

--- a/lib/phase/merge.js
+++ b/lib/phase/merge.js
@@ -12,7 +12,7 @@ const { merge } = require('./flatten');
  * @method fetchPipelineTemplate
  * @method
  * @param   {String}                          pipelineTemplateName                        Pipeline template name
- * @param   {PipelineTemplateVersionFactory}  config.pipelineTemplateVersionFactory       PiplineTemplateVersion Factory to get pipeline templates
+ * @param   {PipelineTemplateVersionFactory}  config.pipelineTemplateVersionFactory       PipelineTemplateVersion Factory to get pipeline templates
  * @param   {PipelineTemplateTagFactory}      config.pipelineTemplateTagFactory           PipelineTemplateTag Factory to get pipeline templates tag
  * @param   {PipelineTemplateFactory}         config.pipelineTemplateFactory              PipelineTemplate Factory to get pipeline templates
  * @return  {Object}                                                                      Pipeline Template
@@ -337,7 +337,7 @@ function mergeConfig(parsedDoc, pipelineTemplate) {
  * Merge pipeline template with screwdriver yaml
  * @method
  * @param   {Object}                          parsedDoc                                   Document that went through structural parsing
- * @param   {PipelineTemplateVersionFactory}  config.pipelineTemplateVersionFactory       PiplineTemplateVersion Factory to get pipeline templates
+ * @param   {PipelineTemplateVersionFactory}  config.pipelineTemplateVersionFactory       PipelineTemplateVersion Factory to get pipeline templates
  * @param   {PipelineTemplateTagFactory}      config.pipelineTemplateTagFactory           PipelineTemplateTag Factory to get pipeline templates tag
  * @param   {PipelineTemplateFactory}         config.pipelineTemplateFactory              PipelineTemplate Factory to get pipeline templates
  * @returns {Promise}                                                                     Merged pipeline and warnings

--- a/test/data/admin-job-annotations.yaml
+++ b/test/data/admin-job-annotations.yaml
@@ -1,0 +1,10 @@
+jobs:
+    main:
+        annotations:
+            screwdriver.cd/adminA: c
+        image: node:22
+        steps:
+            - install: npm install
+        requires:
+            - ~pr
+            - ~commit

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -306,6 +306,14 @@ describe('config parser', () => {
                     assert.deepEqual(data, JSON.parse(loadData('shared-job-annotations.json')));
                 }));
 
+            it('returns error if job has admin annotations', () =>
+                parser({ yaml: loadData('admin-job-annotations.yaml'), triggerFactory }).then(data => {
+                    assert.match(
+                        data.errors[0],
+                        /Error: Annotations starting with screwdriver.cd\/admin are reserved for system use only/
+                    );
+                }));
+
             it('job-level sourcePaths override shared-level sourcePaths', () =>
                 parser({ yaml: loadData('pipeline-with-sourcePaths.yaml'), triggerFactory }).then(data => {
                     assert.deepEqual(data, JSON.parse(loadData('pipeline-with-sourcePaths.json')));


### PR DESCRIPTION
## Context

Build Cluster annotation on a job is currently only derived from pipeline or from screwdriver config.
Screwdriver Admin should have a way to override the behavior to move jobs to specific cluster, but this should be restricted from user

## Objective

This PR prevents user from adding the admin annotation in screwdriver.yaml

## References

https://github.com/screwdriver-cd/screwdriver/issues/3292
https://github.com/screwdriver-cd/data-schema/pull/590

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
