### PR TITLE
fix: update admin annotation prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,8 +89,8 @@ function validateReservedAnnotation(doc) {
                 default: {}
             });
 
-            if (Object.keys(jobAnnotations).some(key => key.startsWith('screwdriver.cd/admin'))) {
-                throw new Error('Annotations starting with screwdriver.cd/admin are reserved for system use only');
+            if (Object.keys(jobAnnotations).some(key => key.startsWith('screwdriver.cd/sdAdmin'))) {
+                throw new Error('Annotations starting with screwdriver.cd/sdAdmin are reserved for system use only');
             }
 
             warnings = warnings.concat(

--- a/test/data/admin-job-annotations.yaml
+++ b/test/data/admin-job-annotations.yaml
@@ -1,7 +1,7 @@
 jobs:
     main:
         annotations:
-            screwdriver.cd/adminA: c
+            screwdriver.cd/sdAdminA: c
         image: node:22
         steps:
             - install: npm install

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -330,7 +330,7 @@ describe('config parser', () => {
                 parser({ yaml: loadData('admin-job-annotations.yaml'), triggerFactory }).then(data => {
                     assert.match(
                         data.errors[0],
-                        /Error: Annotations starting with screwdriver.cd\/admin are reserved for system use only/
+                        /Error: Annotations starting with screwdriver.cd\/sdAdmin are reserved for system use only/
                     );
                 }));
 


### PR DESCRIPTION
## Context

Fix the admin annotation as per data schema

## Objective

This PR updates the admin annotation prefix as per data schema

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
