### PR TITLE
feat(3059): allow sourcePaths with pipeline template [2]

### DIFF
--- a/lib/phase/merge.js
+++ b/lib/phase/merge.js
@@ -4,7 +4,14 @@ const Hoek = require('@hapi/hoek');
 const clone = require('clone');
 const TEMPLATE_NAME_REGEX_WITH_NAMESPACE =
     require('screwdriver-data-schema').config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE;
-const ALLOWED_JOB_FIELDS_WITH_PIPELINE_TEMPLATE = ['settings', 'requires', 'image', 'environment', 'annotations'];
+const ALLOWED_JOB_FIELDS_WITH_PIPELINE_TEMPLATE = [
+    'settings',
+    'requires',
+    'image',
+    'environment',
+    'annotations',
+    'sourcePaths'
+];
 const { merge } = require('./flatten');
 
 /**
@@ -115,6 +122,13 @@ function handlePipelineTemplateMergeForJobs(parsedDoc, newPipeline, pipelineTemp
                         ...newJob.annotations,
                         ...oldJob.annotations
                     };
+                }
+
+                // Merge job sourcePaths
+                if (oldJob.sourcePaths || newJob.sourcePaths) {
+                    newJob.sourcePaths = Array.from(
+                        new Set([...(newJob.sourcePaths || []), ...(oldJob.sourcePaths || [])])
+                    );
                 }
 
                 // Merge settings
@@ -301,6 +315,10 @@ function mergeConfig(parsedDoc, pipelineTemplate) {
 
     if (yamlSharedConfig.image) {
         newPipeline.shared.image = yamlSharedConfig.image;
+    }
+
+    if (yamlSharedConfig.sourcePaths) {
+        newPipeline.shared.sourcePaths = yamlSharedConfig.sourcePaths;
     }
 
     newPipeline.templateVersionId = pipelineTemplate.id;

--- a/test/data/pipeline-template-basic-result.json
+++ b/test/data/pipeline-template-basic-result.json
@@ -26,7 +26,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "sourcePaths": ["pipeline-template"]
         }]
     },
     "workflowGraph": {

--- a/test/data/pipeline-template-with-customized-job-result.json
+++ b/test/data/pipeline-template-with-customized-job-result.json
@@ -73,7 +73,8 @@
                     "room_a"
                 ]
             },
-            "requires": []
+            "requires": [],
+            "sourcePaths": ["pipeline-template", "job"]
         }],
         "job1": [{
             "annotations": {

--- a/test/data/pipeline-template-with-customized-job.yaml
+++ b/test/data/pipeline-template-with-customized-job.yaml
@@ -7,6 +7,7 @@ jobs:
         environment:
             BAR: baz
         requires: []
+        sourcePaths: ["job"]
     job1:
         image: node:10
         settings:

--- a/test/data/pipeline-template-with-new-customized-job-result.json
+++ b/test/data/pipeline-template-with-new-customized-job-result.json
@@ -74,7 +74,8 @@
                     "room_a"
                 ]
             },
-            "requires": []
+            "requires": [],
+            "sourcePaths": ["pipeline-template"]
         }],
         "job1": [{
             "annotations": {

--- a/test/data/pipeline-template-with-pipeline-setting-result.json
+++ b/test/data/pipeline-template-with-pipeline-setting-result.json
@@ -84,7 +84,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "sourcePaths": ["pipeline-template"]
         }],
         "job1": [{
             "annotations": {

--- a/test/data/pipeline-template-with-shared-setting-result.json
+++ b/test/data/pipeline-template-with-shared-setting-result.json
@@ -32,7 +32,8 @@
             "requires": [
                 "~pr",
                 "~commit"
-            ]
+            ],
+            "sourcePaths": ["shared", "pipeline-template"]
         }]
     },
     "workflowGraph": {

--- a/test/data/pipeline-template-with-shared-setting.json
+++ b/test/data/pipeline-template-with-shared-setting.json
@@ -36,7 +36,8 @@
             ],
             "minimized": true
           }
-        }
+        },
+        "sourcePaths": ["pipeline-template"]
       }
     }
   },

--- a/test/data/pipeline-template-with-shared-setting.yaml
+++ b/test/data/pipeline-template-with-shared-setting.yaml
@@ -8,3 +8,4 @@ shared:
         slack:
           channels:
             - test
+    sourcePaths: [ "shared" ]

--- a/test/data/pipeline-template-with-template-setting-result.json
+++ b/test/data/pipeline-template-with-template-setting-result.json
@@ -83,7 +83,8 @@
         "requires": [
           "~pr",
           "~commit"
-        ]
+        ],
+        "sourcePaths": ["pipeline-template"]
       }
     ],
     "job1": [{

--- a/test/data/pipeline-template-with-template-setting.json
+++ b/test/data/pipeline-template-with-template-setting.json
@@ -47,7 +47,8 @@
             ],
             "minimized": true
           }
-        }
+        },
+        "sourcePaths": ["pipeline-template"]
       },
       "job1": {
         "requires": [

--- a/test/data/pipeline-template.json
+++ b/test/data/pipeline-template.json
@@ -8,6 +8,7 @@
       "main": {
         "image": "node:18",
         "requires": ["~pr", "~commit"],
+        "sourcePaths": ["pipeline-template"],
         "steps": [
           {
             "init": "npm install"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -865,7 +865,7 @@ describe('config parser', () => {
                     }).then(data => {
                         assert.deepEqual(
                             data.errors[0],
-                            'Error: Job "main" has unsupported fields in user yaml. Can only set settings,requires,image,environment,annotations.'
+                            'Error: Job "main" has unsupported fields in user yaml. Can only set settings,requires,image,environment,annotations,sourcePaths.'
                         );
                     }));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Users want to customize sourcePaths when they use the pipeline template.

This PR requires the following PR - https://github.com/screwdriver-cd/data-schema/pull/603

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Merge `sourcePaths` settings in pipeline template,  shared, and job.

Example

```yaml
template: sdcd/test@1.0.0 # The "main" job in this pipeline template has "soucePaths: [foo]"

shared:
  sourcePaths: [bar]

jobs:
  main:
    soucePaths: [baz]
```

Then the result is `soucePaths: [foo, bar, baz]` .

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

PR - https://github.com/screwdriver-cd/data-schema/pull/603
Issue - https://github.com/screwdriver-cd/screwdriver/issues/3059


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
