### PR TITLE
feat: skip git clone when the sd.yaml has a config-parser-error

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,9 @@ function parsePipelineYaml({
                                 }
                             ],
                             secrets: [],
-                            environment: {}
+                            environment: {
+                                SD_SKIP_REPOSITORY_CLONE: 'true'
+                            }
                         }
                     ]
                 },

--- a/test/data/bad-build-cluster.json
+++ b/test/data/bad-build-cluster.json
@@ -11,7 +11,9 @@
                     }
                 ],
                 "secrets": [],
-                "environment": {}
+                "environment": {
+                    "SD_SKIP_REPOSITORY_CLONE": "true"
+                }
             }
         ]
     },

--- a/test/data/bad-notification-email-settings.json
+++ b/test/data/bad-notification-email-settings.json
@@ -11,7 +11,9 @@
                   }
               ],
               "secrets": [],
-              "environment": {}
+              "environment": {
+                "SD_SKIP_REPOSITORY_CLONE": "true"
+              }
           }
       ]
   },

--- a/test/data/bad-notification-shared-settings.json
+++ b/test/data/bad-notification-shared-settings.json
@@ -11,7 +11,9 @@
                   }
               ],
               "secrets": [],
-              "environment": {}
+              "environment": {
+                "SD_SKIP_REPOSITORY_CLONE": "true"
+              }
           }
       ]
   },

--- a/test/data/bad-notification-slack-email-settings.json
+++ b/test/data/bad-notification-slack-email-settings.json
@@ -11,7 +11,9 @@
                   }
               ],
               "secrets": [],
-              "environment": {}
+              "environment": {
+                "SD_SKIP_REPOSITORY_CLONE": "true"
+              }
           }
       ]
   },

--- a/test/data/bad-notification-slack-settings.json
+++ b/test/data/bad-notification-slack-settings.json
@@ -11,7 +11,9 @@
                   }
               ],
               "secrets": [],
-              "environment": {}
+              "environment": {
+                "SD_SKIP_REPOSITORY_CLONE": "true"
+              }
           }
       ]
   },

--- a/test/data/pipeline-cache-false-nonexist-job.json
+++ b/test/data/pipeline-cache-false-nonexist-job.json
@@ -11,7 +11,9 @@
                     }
                 ],
                 "secrets": [],
-                "environment": {}
+                "environment": {
+                    "SD_SKIP_REPOSITORY_CLONE": "true"
+                }
             }
         ]
     },

--- a/test/data/pipeline-cache-nonexist-job.json
+++ b/test/data/pipeline-cache-nonexist-job.json
@@ -11,7 +11,9 @@
                     }
                 ],
                 "secrets": [],
-                "environment": {}
+                "environment": {
+                    "SD_SKIP_REPOSITORY_CLONE": "true"
+                }
             }
         ]
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -56,7 +56,7 @@ describe('config parser', () => {
                     });
                     assert.strictEqual(data.jobs.main[0].image, 'node:18');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
-                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.deepEqual(data.jobs.main[0].environment, { SD_SKIP_REPOSITORY_CLONE: 'true' });
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
                     assert.match(data.jobs.main[0].commands[0].command, YAMLMISSING);
                     assert.match(data.errors[0], YAMLMISSING);
@@ -67,7 +67,7 @@ describe('config parser', () => {
                 parser({ yaml: 'foo: :' }).then(data => {
                     assert.strictEqual(data.jobs.main[0].image, 'node:18');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
-                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.deepEqual(data.jobs.main[0].environment, { SD_SKIP_REPOSITORY_CLONE: 'true' });
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
                     assert.match(data.jobs.main[0].commands[0].command, /YAMLException:/);
                     assert.match(data.errors[0], /YAMLException:/);
@@ -77,7 +77,7 @@ describe('config parser', () => {
                 parser({ yaml: loadData('basic-job-with-duplicate-steps.yaml') }).then(data => {
                     assert.strictEqual(data.jobs.main[0].image, 'node:18');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
-                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.deepEqual(data.jobs.main[0].environment, { SD_SKIP_REPOSITORY_CLONE: 'true' });
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
                     assert.match(data.jobs.main[0].commands[0].command, /Error:.*main has duplicate step: publish/);
                     assert.match(data.errors[0], /Error:.*main has duplicate step: publish/);
@@ -95,7 +95,7 @@ describe('config parser', () => {
                 parser({ yaml: 'foo: bar\n---\nfoo: baz' }).then(data => {
                     assert.strictEqual(data.jobs.main[0].image, 'node:18');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
-                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.deepEqual(data.jobs.main[0].environment, { SD_SKIP_REPOSITORY_CLONE: 'true' });
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
                     assert.match(data.jobs.main[0].commands[0].command, /YAMLException:.*ambigious/);
                     assert.match(data.errors[0], /YAMLException:.*ambigious/);
@@ -105,7 +105,7 @@ describe('config parser', () => {
                 parser({ yaml: 'jobs: {}\n---\nversion: 4' }).then(data => {
                     assert.strictEqual(data.jobs.main[0].image, 'node:18');
                     assert.deepEqual(data.jobs.main[0].secrets, []);
-                    assert.deepEqual(data.jobs.main[0].environment, {});
+                    assert.deepEqual(data.jobs.main[0].environment, { SD_SKIP_REPOSITORY_CLONE: 'true' });
                     assert.strictEqual(data.jobs.main[0].commands[0].name, 'config-parse-error');
                     assert.match(data.errors[0], 'ValidationError: "jobs" is required');
                 }));


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The build only show the error message when the screwdriver.yaml has a config-parser-error.
It does not need all source code in the repository.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add `SD_SKIP_REPOSITORY_CLONE` environment to skip `git clone` when the sd.yaml has a config-parser-error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
