### PR TITLE
fix: Reduce the number of fetches for job templates

### DIFF
--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -352,8 +352,8 @@ function handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig, template })
  * Retrieve template and merge into job config
  *
  * @method mergeTemplateIntoJob
- * @param  {String}           jobName               Job name
- * @param  {Object}           jobConfig             Job config
+ * @param  {String[]}         jobNames              Job names
+ * @param  {Object[]}         jobConfigs            Job configs
  * @param  {Object}           newJobs               Object with all the jobs
  * @param  {TemplateFactory}  templateFactory       Template Factory to get templates
  * @param  {Object}           sharedConfig          Shared configuration
@@ -362,18 +362,21 @@ function handleMergeSharedStepsAnnotation({ sharedConfig, jobConfig, template })
  * @return {Promise}
  */
 async function mergeTemplateIntoJob({
-    jobName,
-    jobConfig,
+    jobNames,
+    jobConfigs,
     newJobs,
     templateFactory,
     sharedConfig,
     pipelineParameters,
     isPipelineTemplate
 }) {
-    let oldJob = jobConfig;
+    const template = await templateFactory.getTemplate(jobConfigs[0].template);
 
     // Try to get the template
-    return templateFactory.getTemplate(jobConfig.template).then(template => {
+    return jobNames.map((jobName, i) => {
+        const jobConfig = jobConfigs[i];
+        let oldJob = jobConfig;
+
         if (!template) {
             throw new Error(`Template ${jobConfig.template} does not exist`);
         }
@@ -453,52 +456,61 @@ async function mergeTemplateIntoJob({
  */
 async function flattenTemplates(doc, templateFactory, isPipelineTemplate) {
     const newJobs = {};
-    const templates = [];
+    const orderWarnings = [];
     const { jobs, shared, parameters } = doc;
-    const jobNames = Object.keys(jobs);
+    const allJobNames = Object.keys(jobs);
 
-    jobNames.forEach(jobName => {
-        const jobConfig = clone(jobs[jobName]);
-        const templateConfig = jobConfig.template;
-        const order = jobConfig.order || [];
-        let warnMessages = [];
+    const jobGroupByTemplate = {};
 
-        // Validate order is used with template
-        if (order.length > 0 && templateConfig === undefined) {
-            warnMessages = warnMessages.concat(`"order" in ${jobName} job cannot be used without "template"`);
+    allJobNames.forEach(jobName => {
+        const templateName = jobs[jobName].template;
 
-            templates.push(warnMessages);
+        if (!templateName) {
+            const jobConfig = clone(jobs[jobName]);
+            const order = jobConfig.order || [];
+
+            // Validate order is used with template
+            if (order.length > 0 && templateName === undefined) {
+                orderWarnings.push(`"order" in ${jobName} job cannot be used without "template"`);
+            }
+            newJobs[jobName] = jobConfig;
+
+            return;
         }
+        if (jobGroupByTemplate[templateName] === undefined) {
+            jobGroupByTemplate[templateName] = [jobName];
+        } else {
+            jobGroupByTemplate[templateName].push(jobName);
+        }
+    });
+
+    const promises = Object.entries(jobGroupByTemplate).map(([templateName, jobNames]) => {
+        const jobConfigs = jobNames.map(jobName => clone(jobs[jobName]));
 
         // If template is specified, then merge
-        if (templateConfig) {
-            templates.push(
-                mergeTemplateIntoJob({
-                    jobName,
-                    jobConfig,
-                    newJobs,
-                    templateFactory,
-                    sharedConfig: shared,
-                    pipelineParameters: parameters,
-                    isPipelineTemplate
-                })
-            );
-        } else {
-            newJobs[jobName] = jobConfig; // Otherwise just use jobConfig
-        }
+        return mergeTemplateIntoJob({
+            jobNames,
+            jobConfigs,
+            newJobs,
+            templateFactory,
+            templateName,
+            sharedConfig: shared,
+            pipelineParameters: parameters,
+            isPipelineTemplate
+        });
     });
 
     // Wait until all promises are resolved
     // Inserting newJobs with template is delayed, hence the order of newJobs.keys is incompatible to doc.jobs.keys
-    return Promise.all(templates).then(warnings => {
+    return Promise.all(promises).then(warnings => {
         const sortedNewJobs = {};
 
-        jobNames.forEach(jobName => {
+        allJobNames.forEach(jobName => {
             sortedNewJobs[jobName] = newJobs[jobName];
         });
 
         return {
-            warnings: [].concat(...warnings),
+            warnings: [].concat(...orderWarnings, ...warnings.flat()),
             newJobs: sortedNewJobs
         };
     });

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -484,7 +484,7 @@ async function flattenTemplates(doc, templateFactory, isPipelineTemplate) {
         }
     });
 
-    const promises = Object.entries(jobGroupByTemplate).map(([templateName, jobNames]) => {
+    const promises = Object.values(jobGroupByTemplate).map(jobNames => {
         const jobConfigs = jobNames.map(jobName => clone(jobs[jobName]));
 
         // If template is specified, then merge
@@ -493,7 +493,6 @@ async function flattenTemplates(doc, templateFactory, isPipelineTemplate) {
             jobConfigs,
             newJobs,
             templateFactory,
-            templateName,
             sharedConfig: shared,
             pipelineParameters: parameters,
             isPipelineTemplate

--- a/lib/phase/flatten.js
+++ b/lib/phase/flatten.js
@@ -381,7 +381,7 @@ async function mergeTemplateIntoJob({
             throw new Error(`Template ${jobConfig.template} does not exist`);
         }
 
-        const newJob = template.config;
+        const newJob = clone(template.config);
         const environment = newJob.environment || {};
 
         // Construct full template name

--- a/test/data/basic-job-with-parameters-and-template-without-parameters.json
+++ b/test/data/basic-job-with-parameters-and-template-without-parameters.json
@@ -15,6 +15,8 @@
         ],
         "description": "This is the main description",
         "environment": {
+          "BAR": "foo",
+          "FOO": "from yourtemplate",
           "SD_TEMPLATE_FULLNAME": "yourtemplate",
           "SD_TEMPLATE_NAME": "yourtemplate",
           "SD_TEMPLATE_NAMESPACE": "",

--- a/test/data/basic-job-with-same-template-different-version.json
+++ b/test/data/basic-job-with-same-template-different-version.json
@@ -1,0 +1,99 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                }
+            ],
+            "environment": {
+                "FOO": "overwritten by job",
+                "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }],
+      "publish1": [{
+          "annotations": {},
+          "image": "node:4",
+          "commands": [
+              {
+                  "name": "publish",
+                  "command": "npm publish"
+              }
+          ],
+          "environment": {
+              "SD_TEMPLATE_FULLNAME": "yourtemplate",
+              "SD_TEMPLATE_NAME": "yourtemplate",
+              "SD_TEMPLATE_NAMESPACE": "",
+              "SD_TEMPLATE_VERSION": "2"
+          },
+          "secrets": [],
+          "settings": {},
+          "requires": [
+              "main"
+          ],
+          "templateId": 1234
+      }],
+      "publish2": [{
+        "annotations": {},
+        "image": "node:4",
+        "commands": [
+          {
+            "name": "publish",
+            "command": "npm publish"
+          }
+        ],
+        "environment": {
+          "SD_TEMPLATE_FULLNAME": "yourtemplate",
+          "SD_TEMPLATE_NAME": "yourtemplate",
+          "SD_TEMPLATE_NAMESPACE": "",
+          "SD_TEMPLATE_VERSION": "3"
+        },
+        "secrets": [],
+        "settings": {},
+        "requires": [
+          "main"
+        ],
+        "templateId": 1234
+      }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish1" },
+            { "name": "publish2" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish1", "join": true },
+            { "src": "main", "dest": "publish2", "join": true }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-job-with-same-template-different-version.json
+++ b/test/data/basic-job-with-same-template-different-version.json
@@ -45,6 +45,8 @@
               }
           ],
           "environment": {
+              "BAR": "foo",
+              "FOO": "from yourtemplate",
               "SD_TEMPLATE_FULLNAME": "yourtemplate",
               "SD_TEMPLATE_NAME": "yourtemplate",
               "SD_TEMPLATE_NAMESPACE": "",

--- a/test/data/basic-job-with-same-template-different-version.yaml
+++ b/test/data/basic-job-with-same-template-different-version.yaml
@@ -1,0 +1,17 @@
+jobs:
+    main:
+        template: mytemplate@1.2.3
+        environment:
+            FOO: 'overwritten by job'
+        requires:
+            - ~pr
+            - ~commit
+    publish1:
+        template: yourtemplate@2
+        requires:
+            - main
+
+    publish2:
+        template: yourtemplate@3
+        requires:
+            - main

--- a/test/data/basic-job-with-same-template.json
+++ b/test/data/basic-job-with-same-template.json
@@ -45,6 +45,9 @@
               }
           ],
           "environment": {
+              "FOO": "from yourtemplate",
+              "BAR": "bar1",
+              "BAZ": "baz1",
               "SD_TEMPLATE_FULLNAME": "yourtemplate",
               "SD_TEMPLATE_NAME": "yourtemplate",
               "SD_TEMPLATE_NAMESPACE": "",
@@ -67,6 +70,9 @@
           }
         ],
         "environment": {
+          "FOO": "from yourtemplate",
+          "BAR": "foo",
+          "BAZ": "baz2",
           "SD_TEMPLATE_FULLNAME": "yourtemplate",
           "SD_TEMPLATE_NAME": "yourtemplate",
           "SD_TEMPLATE_NAMESPACE": "",

--- a/test/data/basic-job-with-same-template.json
+++ b/test/data/basic-job-with-same-template.json
@@ -1,0 +1,99 @@
+{
+    "annotations": {},
+    "parameters": {},
+    "jobs": {
+        "main": [{
+            "annotations": {},
+            "image": "node:4",
+            "commands": [
+                {
+                    "name": "install",
+                    "command": "npm install"
+                },
+                {
+                    "name": "test",
+                    "command": "npm test"
+                }
+            ],
+            "environment": {
+                "FOO": "overwritten by job",
+                "BAR": "foo",
+                "SD_TEMPLATE_FULLNAME": "mytemplate",
+                "SD_TEMPLATE_NAME": "mytemplate",
+                "SD_TEMPLATE_NAMESPACE": "",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "secrets": [
+                "GIT_KEY"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "requires": [
+                "~pr",
+                "~commit"
+            ],
+            "templateId": 7754
+        }],
+      "publish1": [{
+          "annotations": {},
+          "image": "node:4",
+          "commands": [
+              {
+                  "name": "publish",
+                  "command": "npm publish"
+              }
+          ],
+          "environment": {
+              "SD_TEMPLATE_FULLNAME": "yourtemplate",
+              "SD_TEMPLATE_NAME": "yourtemplate",
+              "SD_TEMPLATE_NAMESPACE": "",
+              "SD_TEMPLATE_VERSION": "2"
+          },
+          "secrets": [],
+          "settings": {},
+          "requires": [
+              "main"
+          ],
+          "templateId": 1234
+      }],
+      "publish2": [{
+        "annotations": {},
+        "image": "node:4",
+        "commands": [
+          {
+            "name": "publish",
+            "command": "npm publish"
+          }
+        ],
+        "environment": {
+          "SD_TEMPLATE_FULLNAME": "yourtemplate",
+          "SD_TEMPLATE_NAME": "yourtemplate",
+          "SD_TEMPLATE_NAMESPACE": "",
+          "SD_TEMPLATE_VERSION": "2"
+        },
+        "secrets": [],
+        "settings": {},
+        "requires": [
+          "main"
+        ],
+        "templateId": 1234
+      }]
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish1" },
+            { "name": "publish2" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish1", "join": true },
+            { "src": "main", "dest": "publish2", "join": true }
+        ]
+    },
+    "subscribe": {}
+}

--- a/test/data/basic-job-with-same-template.yaml
+++ b/test/data/basic-job-with-same-template.yaml
@@ -8,10 +8,15 @@ jobs:
             - ~commit
     publish1:
         template: yourtemplate@2
+        environment:
+            BAR: "bar1"
+            BAZ: "baz1"
         requires:
             - main
 
     publish2:
         template: yourtemplate@2
+        environment:
+            BAZ: "baz2"
         requires:
             - main

--- a/test/data/basic-job-with-same-template.yaml
+++ b/test/data/basic-job-with-same-template.yaml
@@ -1,0 +1,17 @@
+jobs:
+    main:
+        template: mytemplate@1.2.3
+        environment:
+            FOO: 'overwritten by job'
+        requires:
+            - ~pr
+            - ~commit
+    publish1:
+        template: yourtemplate@2
+        requires:
+            - main
+
+    publish2:
+        template: yourtemplate@2
+        requires:
+            - main

--- a/test/data/basic-job-with-shared-and-template-override-steps.json
+++ b/test/data/basic-job-with-shared-and-template-override-steps.json
@@ -49,7 +49,7 @@
                 },
                 {
                     "name": "test",
-                    "command": "echo 'my job is overriding this step'"
+                    "command": "npm test"
                 }
             ],
             "environment": {
@@ -66,10 +66,6 @@
             "settings": {
                 "email": "foo@example.com"
             },
-            "requires": [
-                "~pr",
-                "~commit"
-            ],
             "templateId": 7754
         }]
     },
@@ -82,9 +78,7 @@
         ],
         "edges": [
             { "src": "~pr", "dest": "main" },
-            { "src": "~commit", "dest": "main" },
-            { "src": "~pr", "dest": "second" },
-            { "src": "~commit", "dest": "second" }
+            { "src": "~commit", "dest": "main" }
         ]
     },
     "subscribe": {}

--- a/test/data/basic-job-with-template.json
+++ b/test/data/basic-job-with-template.json
@@ -45,6 +45,8 @@
               }
           ],
           "environment": {
+              "BAR": "foo",
+              "FOO": "from yourtemplate",
               "SD_TEMPLATE_FULLNAME": "yourtemplate",
               "SD_TEMPLATE_NAME": "yourtemplate",
               "SD_TEMPLATE_NAMESPACE": "",

--- a/test/data/template-2-3.json
+++ b/test/data/template-2-3.json
@@ -1,0 +1,14 @@
+{
+    "id": 1234,
+    "name": "yourtemplate",
+    "version": "3",
+    "description": "test template",
+    "maintainer": "foo@bar.com",
+    "labels": [],
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "publish": "npm publish" }
+        ]
+    }
+}

--- a/test/data/template-2.json
+++ b/test/data/template-2.json
@@ -9,6 +9,10 @@
         "image": "node:4",
         "steps": [
             { "publish": "npm publish" }
-        ]
+        ],
+        "environment": {
+            "FOO": "from yourtemplate",
+            "BAR": "foo"
+        }
     }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -436,6 +436,16 @@ describe('config parser', () => {
                         triggerFactory
                     }).then(data => assert.deepEqual(data, JSON.parse(loadData('basic-job-with-template.json')))));
 
+                it('flattens templates successfully When there are multiple jobs that use the same template', () =>
+                    parser({
+                        yaml: loadData('basic-job-with-same-template.yaml'),
+                        templateFactory: templateFactoryMock,
+                        triggerFactory
+                    }).then(data => {
+                        assert.deepEqual(data, JSON.parse(loadData('basic-job-with-same-template.json')));
+                        assert.calledTwice(templateFactoryMock.getTemplate);
+                    }));
+
                 it('flattens templates successfully when template namespace exists', () => {
                     templateFactoryMock.getTemplate.withArgs('yourtemplate@2').resolves(defaultTemplate);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -375,6 +375,7 @@ describe('config parser', () => {
             describe('templates', () => {
                 let firstTemplate;
                 let secondTemplate;
+                let secondTemplateVersion3;
                 let namespaceTemplate;
                 let defaultTemplate;
                 let imagesTemplate;
@@ -389,6 +390,7 @@ describe('config parser', () => {
                 beforeEach(() => {
                     firstTemplate = JSON.parse(loadData('template.json'));
                     secondTemplate = JSON.parse(loadData('template-2.json'));
+                    secondTemplateVersion3 = JSON.parse(loadData('template-2-3.json'));
                     namespaceTemplate = JSON.parse(loadData('templateWithNamespace.json'));
                     defaultTemplate = JSON.parse(loadData('templateWithDefaultNamespace.json'));
                     imagesTemplate = JSON.parse(loadData('templateWithImages.json'));
@@ -402,6 +404,7 @@ describe('config parser', () => {
                     templateFactoryMock.getFullNameAndVersion.returns({ isVersion: true });
                     templateFactoryMock.getTemplate.withArgs('mytemplate@1.2.3').resolves(firstTemplate);
                     templateFactoryMock.getTemplate.withArgs('yourtemplate@2').resolves(secondTemplate);
+                    templateFactoryMock.getTemplate.withArgs('yourtemplate@3').resolves(secondTemplateVersion3);
                     templateFactoryMock.getTemplate
                         .withArgs('mynamespace/mytemplate@1.2.3')
                         .resolves(namespaceTemplate);
@@ -444,6 +447,19 @@ describe('config parser', () => {
                     }).then(data => {
                         assert.deepEqual(data, JSON.parse(loadData('basic-job-with-same-template.json')));
                         assert.calledTwice(templateFactoryMock.getTemplate);
+                    }));
+
+                it('flattens templates successfully When there are multiple jobs that use the same template different version', () =>
+                    parser({
+                        yaml: loadData('basic-job-with-same-template-different-version.yaml'),
+                        templateFactory: templateFactoryMock,
+                        triggerFactory
+                    }).then(data => {
+                        assert.deepEqual(
+                            data,
+                            JSON.parse(loadData('basic-job-with-same-template-different-version.json'))
+                        );
+                        assert.callCount(templateFactoryMock.getTemplate, 3);
                     }));
 
                 it('flattens templates successfully when template namespace exists', () => {


### PR DESCRIPTION
## Context
Even when multiple jobs using the same template exist within a pipeline, each job attempts to retrieve the template from the database individually.

This poses a problem of increased load on the database for pipelines with a very large number of jobs.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Reduce the number of fetches for same job templates

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
