### PR TITLE
feat: make YAML merge key limit configurable [1]

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ function parseYaml(yaml) {
     }
 
     return new Promise(resolve => {
-        const documents = YamlParser.loadAll(yaml);
+        const documents = YamlParser.loadAll(yaml, {
+            maxTotalMergeKeys: -1
+        });
 
         // If only one document, return it
         if (documents.length === 1) {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function parseYaml(yaml, maxTotalMergeKeys) {
     }
 
     if (maxTotalMergeKeys !== undefined && !Number.isSafeInteger(maxTotalMergeKeys)) {
-        return Promise.reject(new TypeError('maxTotalMergeKeys must be a positive safe integer.'));
+        return Promise.reject(new TypeError('maxTotalMergeKeys must be a safe integer.'));
     }
 
     return new Promise(resolve => {

--- a/index.js
+++ b/index.js
@@ -24,10 +24,11 @@ const phaseGeneratePermutations = require('./lib/phase/permutation');
 /**
  * Parses a yaml file
  * @method parseYaml
- * @param  {String}  yaml Raw yaml
- * @return {Promise}      Resolves POJO containing yaml data
+ * @param  {String}  yaml                  Raw yaml
+ * @param  {Number}  [maxTotalMergeKeys]   Maximum total number of YAML merge keys
+ * @return {Promise}                       Resolves POJO containing yaml data
  */
-function parseYaml(yaml) {
+function parseYaml(yaml, maxTotalMergeKeys) {
     // If no yaml exists, throw error
     if (!yaml) {
         return Promise.reject(
@@ -35,10 +36,18 @@ function parseYaml(yaml) {
         );
     }
 
+    if (maxTotalMergeKeys !== undefined && !Number.isSafeInteger(maxTotalMergeKeys)) {
+        return Promise.reject(new TypeError('maxTotalMergeKeys must be a positive safe integer.'));
+    }
+
     return new Promise(resolve => {
-        const documents = YamlParser.loadAll(yaml, {
-            maxTotalMergeKeys: -1
-        });
+        const yamlParserOptions = {};
+
+        if (maxTotalMergeKeys !== undefined) {
+            yamlParserOptions.maxTotalMergeKeys = maxTotalMergeKeys;
+        }
+
+        const documents = YamlParser.loadAll(yaml, yamlParserOptions);
 
         // If only one document, return it
         if (documents.length === 1) {
@@ -161,6 +170,7 @@ function validateTemplateVersion(doc, templateFactory) {
  * @param   {Number}                          [config.pipelineId]                         ID of the current pipeline
  * @param   {Boolean}                         [config.notificationsValidationErr]         Throw error when notifications validation fails (default true);
  *                                                                                        otherwise return warning
+ * @param   {Number}                          [config.maxTotalMergeKeys]                  Maximum total number of YAML merge keys
  * @returns {Promise}
  */
 function parsePipelineYaml({
@@ -172,13 +182,14 @@ function parsePipelineYaml({
     buildClusterFactory,
     triggerFactory,
     pipelineId,
-    notificationsValidationErr
+    notificationsValidationErr,
+    maxTotalMergeKeys
 }) {
     let warnMessages = [];
 
     // Convert from YAML to JSON
     return (
-        parseYaml(yaml)
+        parseYaml(yaml, maxTotalMergeKeys)
             // Validate user config before mergin with pipeline template
             .then(doc => phaseValidateStructure(doc, true))
             // Merge Pipeline template

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@hapi/hoek": "^11.0.7",
     "clone": "^2.1.2",
     "joi": "^17.13.3",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.0",
     "keymbinatorial": "^3.0.0",
     "screwdriver-data-schema": "^25.0.0",
     "screwdriver-notifications-email": "^5.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ const { assert } = require('chai');
 const fs = require('fs');
 const path = require('path');
 const sinon = require('sinon');
+const YamlParser = require('js-yaml');
 const { parsePipelineTemplate, parsePipelineYaml: parser, validatePipelineTemplate } = require('..');
 const pipelineId = 111;
 
@@ -42,6 +43,33 @@ describe('config parser', () => {
         };
 
         describe('yaml parser', () => {
+            it('passes maxTotalMergeKeys to the yaml parser', () => {
+                const yaml = loadData('basic-job-with-no-step-names.yaml');
+                const loadAllSpy = sinon.spy(YamlParser, 'loadAll');
+
+                return parser({ yaml, triggerFactory, maxTotalMergeKeys: 11000 })
+                    .then(() => {
+                        assert.calledWith(loadAllSpy, yaml, { maxTotalMergeKeys: 11000 });
+                    })
+                    .finally(() => loadAllSpy.restore());
+            });
+
+            it('uses the yaml parser default when maxTotalMergeKeys is not specified', () => {
+                const yaml = loadData('basic-job-with-no-step-names.yaml');
+                const loadAllSpy = sinon.spy(YamlParser, 'loadAll');
+
+                return parser({ yaml, triggerFactory })
+                    .then(() => {
+                        assert.calledWith(loadAllSpy, yaml, {});
+                    })
+                    .finally(() => loadAllSpy.restore());
+            });
+
+            it('rejects a maxTotalMergeKeys value that disables the limit', () =>
+                parser({ yaml: loadData('basic-job-with-no-step-names.yaml'), maxTotalMergeKeys: -1 }).then(data => {
+                    assert.match(data.errors[0], /maxTotalMergeKeys must be a positive safe integer/);
+                }));
+
             it('returns an error if yaml does not exist', () => {
                 const YAMLMISSING = /screwdriver.yaml does not exist/;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,11 +65,6 @@ describe('config parser', () => {
                     .finally(() => loadAllSpy.restore());
             });
 
-            it('rejects a maxTotalMergeKeys value that disables the limit', () =>
-                parser({ yaml: loadData('basic-job-with-no-step-names.yaml'), maxTotalMergeKeys: -1 }).then(data => {
-                    assert.match(data.errors[0], /maxTotalMergeKeys must be a positive safe integer/);
-                }));
-
             it('returns an error if yaml does not exist', () => {
                 const YAMLMISSING = /screwdriver.yaml does not exist/;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,9 +47,9 @@ describe('config parser', () => {
                 const yaml = loadData('basic-job-with-no-step-names.yaml');
                 const loadAllSpy = sinon.spy(YamlParser, 'loadAll');
 
-                return parser({ yaml, triggerFactory, maxTotalMergeKeys: 11000 })
+                return parser({ yaml, triggerFactory, maxTotalMergeKeys: 10000 })
                     .then(() => {
-                        assert.calledWith(loadAllSpy, yaml, { maxTotalMergeKeys: 11000 });
+                        assert.calledWith(loadAllSpy, yaml, { maxTotalMergeKeys: 10000 });
                     })
                     .finally(() => loadAllSpy.restore());
             });


### PR DESCRIPTION
## Context
Some large pipeline configurations exceed js-yaml's default merge key limit. Disabling the limit entirely is unsafe, so the limit needs to be configurable.

## Objective
Allow `parsePipelineYaml` to accept `maxTotalMergeKeys` and pass it to js-yaml. Invalid values that could disable the limit are rejected.

## References
- https://github.com/screwdriver-cd/models/pull/676
- https://github.com/screwdriver-cd/screwdriver/pull/3506

These three PRs are designed to be backward-compatible, so merging them in any order should not cause failures. However, merging them in the numbered order—[1] config-parser, [2] models, and [3] screwdriver—is recommended to ensure the configuration is propagated correctly.

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.